### PR TITLE
Add daily triage automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,9 @@ Thumbs.db
 # Claude Code settings
 .claude/settings.local.json
 
+# Triage automation data (personal, never published to the public repo)
+.triage/
+
 # Bun
 bun.lockb
 

--- a/scripts/triage/README.md
+++ b/scripts/triage/README.md
@@ -1,0 +1,85 @@
+# Triage automation
+
+A self-resuming morning loop that triages CI failures, open issues, and recent
+commits, drafts fixes in isolated worktrees, opens PRs on green, and keeps
+contributors out of limbo with comments in the maintainer's voice.
+
+The **machinery** (this dir + `skills/triage/`) is committed. The **data**
+(`.triage/`: state, inbox, runs, voice) is gitignored and lives only on the
+machine that runs the loop.
+
+## Parts
+
+```
+skills/triage/SKILL.md            the loop the agent follows
+skills/triage/resources/          state schema, finding rules, comment policy
+scripts/triage/run.sh             host-agnostic entry point
+scripts/triage/bootstrap.sh       scaffolds .triage/ (idempotent)
+scripts/triage/prompt.md          the morning prompt
+.triage/state.json                the spine: what was tried/passed/open
+.triage/inbox.md                  human queue + comment drafts
+.triage/runs/<date>.md            per-run audit log
+.triage/voice.md                  distilled maintainer voice
+```
+
+## First run
+
+```bash
+gh auth status                  # must be authenticated
+scripts/triage/bootstrap.sh     # scaffold .triage/ (run.sh also does this)
+DRY_RUN=1 scripts/triage/run.sh # preflight + show the prompt, no agent
+scripts/triage/run.sh           # the real thing
+```
+
+## Schedule it (local host)
+
+State is local-only, so the loop runs on your machine. launchd example
+(`~/Library/LaunchAgents/org.mcpvault.triage.plist`), 07:00 daily:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.mcpvault.triage</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>/Users/mwolff/bit/mcpvault/scripts/triage/run.sh</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict><key>Hour</key><integer>7</integer><key>Minute</key><integer>0</integer></dict>
+  <key>StandardOutPath</key><string>/tmp/mcpvault-triage.out</string>
+  <key>StandardErrorPath</key><string>/tmp/mcpvault-triage.err</string>
+</dict>
+</plist>
+```
+
+```bash
+launchctl load ~/Library/LaunchAgents/org.mcpvault.triage.plist
+```
+
+Or use Claude Code's `CronCreate` to schedule the same `run.sh`.
+
+## Moving to a CI host later
+
+GitHub Actions runners are ephemeral, so the spine (`.triage/state.json`) must
+persist between runs. To move the loop to Actions:
+
+1. Persist `.triage/` between runs — commit a redacted state to a dedicated
+   branch, or store it as a workflow artifact / private gist.
+2. Add the `ANTHROPIC_API_KEY` and a `gh` token as repo secrets.
+3. Add a scheduled workflow that checks out, restores `.triage/`, runs
+   `scripts/triage/run.sh`, and saves `.triage/` back.
+
+Until then the loop is local-only by design — it keeps your triage notes and
+voice profile off the public repo.
+
+## Safety
+
+- PRs only. Never pushes to main, never merges, never force-pushes.
+- Touches nothing outside worktrees except `.triage/`.
+- Auto-posts only low-risk acknowledgments; every substantive comment is
+  drafted to the inbox for approval. See `skills/triage/resources/comment-policy.md`.
+- Caps: 3 fixes/run, 2 attempts/finding, 2 files/fix. Overflow spills to inbox.

--- a/scripts/triage/README.md
+++ b/scripts/triage/README.md
@@ -67,13 +67,13 @@ Or use Claude Code's `CronCreate` to schedule the same `run.sh`.
 GitHub Actions runners are ephemeral, so the spine (`.triage/state.json`) must
 persist between runs. To move the loop to Actions:
 
-1. Persist `.triage/` between runs — commit a redacted state to a dedicated
+1. Persist `.triage/` between runs, commit a redacted state to a dedicated
    branch, or store it as a workflow artifact / private gist.
 2. Add the `ANTHROPIC_API_KEY` and a `gh` token as repo secrets.
 3. Add a scheduled workflow that checks out, restores `.triage/`, runs
    `scripts/triage/run.sh`, and saves `.triage/` back.
 
-Until then the loop is local-only by design — it keeps your triage notes and
+Until then the loop is local-only by design, it keeps your triage notes and
 voice profile off the public repo.
 
 ## Safety

--- a/scripts/triage/bootstrap.sh
+++ b/scripts/triage/bootstrap.sh
@@ -45,7 +45,7 @@ if [[ ! -f "$TRIAGE_DIR/voice.md" ]]; then
   cat > "$TRIAGE_DIR/voice.md" <<'MD'
 # Maintainer voice
 
-> PLACEHOLDER — not yet distilled. The triage skill will populate this from
+> PLACEHOLDER, not yet distilled. The triage skill will populate this from
 > past gh comments on first run (see comment-policy.md). Until then, the loop
 > drafts all comments and auto-posts none.
 

--- a/scripts/triage/bootstrap.sh
+++ b/scripts/triage/bootstrap.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Scaffold the gitignored .triage/ data dir. Idempotent: safe to re-run.
+# Seeds state.json, inbox.md, runs/, and a placeholder voice.md. The voice
+# profile is distilled by the triage skill on first run (see comment-policy.md).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TRIAGE_DIR="$REPO_ROOT/.triage"
+
+mkdir -p "$TRIAGE_DIR/runs"
+
+if [[ ! -f "$TRIAGE_DIR/state.json" ]]; then
+  cat > "$TRIAGE_DIR/state.json" <<'JSON'
+{
+  "version": 1,
+  "last_run": null,
+  "findings": {}
+}
+JSON
+  echo "created .triage/state.json"
+fi
+
+if [[ ! -f "$TRIAGE_DIR/inbox.md" ]]; then
+  cat > "$TRIAGE_DIR/inbox.md" <<'MD'
+# Triage inbox
+
+Everything the morning loop could not handle on its own. Read this first.
+
+## Needs decision
+
+_Findings parked for a human call. Each: finding id, source, what was tried, why it's here, smallest next action._
+
+## Drafts awaiting approval
+
+_Substantive comments written in your voice, not yet posted. Approve, edit, or discard._
+MD
+  echo "created .triage/inbox.md"
+fi
+
+if [[ ! -f "$TRIAGE_DIR/voice.md" ]]; then
+  cat > "$TRIAGE_DIR/voice.md" <<'MD'
+# Maintainer voice
+
+> PLACEHOLDER — not yet distilled. The triage skill will populate this from
+> past gh comments on first run (see comment-policy.md). Until then, the loop
+> drafts all comments and auto-posts none.
+
+## Tone
+
+## Habits
+
+## Phrases
+MD
+  echo "created .triage/voice.md (placeholder)"
+fi
+
+echo "bootstrap complete: $TRIAGE_DIR"

--- a/scripts/triage/bootstrap.sh
+++ b/scripts/triage/bootstrap.sh
@@ -26,6 +26,10 @@ if [[ ! -f "$TRIAGE_DIR/inbox.md" ]]; then
 
 Everything the morning loop could not handle on its own. Read this first.
 
+## Open commitments (you promised, not shipped)
+
+_Threads where you said you'd do something and it hasn't shipped. Each: thread, the quoted promise, how long ago, current state, whether a fix was drafted._
+
 ## Needs decision
 
 _Findings parked for a human call. Each: finding id, source, what was tried, why it's here, smallest next action._

--- a/scripts/triage/prompt.md
+++ b/scripts/triage/prompt.md
@@ -1,0 +1,21 @@
+Run the daily repository triage.
+
+Activate the `triage` skill and follow its loop exactly:
+
+1. Gather yesterday's signals (CI failures, open issues, recent commits) via gh.
+2. Load `.triage/state.json` and dedupe against known findings by id.
+3. Classify each signal with the finding rules (worth-doing / inbox / ignore).
+4. For each worth-doing finding (up to the per-run cap), open an isolated
+   worktree, send a draft sub-agent then a review sub-agent, and open a ready PR
+   only on a passing review with green `npm test && npm run build`.
+5. Persist the state file and write the per-run log.
+6. Keep contributors out of limbo: auto-post low-risk acknowledgments, draft all
+   substantive comments to the inbox.
+7. Spill anything unhandled to `.triage/inbox.md`.
+
+Constraints: never push to main, never merge, never force. PRs only. Mutate
+nothing outside worktrees except `.triage/`. If gh is unauthenticated or the
+tree is dirty, abort and write why to the inbox.
+
+When you finish, print a one-screen summary: signals gathered, findings new vs
+known, PRs opened, comments posted, items sent to inbox.

--- a/scripts/triage/run.sh
+++ b/scripts/triage/run.sh
@@ -21,7 +21,7 @@ gh auth status >/dev/null 2>&1 || fail "gh not authenticated (run: gh auth login
 
 if [[ -n "$(git status --porcelain)" ]]; then
   if [[ "${DRY_RUN:-0}" == "1" ]]; then
-    echo "triage: warning — working tree is dirty (ok for dry run; a real run aborts here)" >&2
+    echo "triage: warning, working tree is dirty (ok for dry run; a real run aborts here)" >&2
   else
     fail "working tree is dirty; triage needs a clean main checkout"
   fi

--- a/scripts/triage/run.sh
+++ b/scripts/triage/run.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Host-agnostic entry point for the morning triage run.
+# Run it from launchd/cron locally, or from a CI runner if you later commit
+# state. It just preflights and hands the prompt to a headless Claude Code run.
+#
+#   scripts/triage/run.sh            # real run
+#   DRY_RUN=1 scripts/triage/run.sh  # preflight + print prompt, no agent
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PROMPT_FILE="$REPO_ROOT/scripts/triage/prompt.md"
+
+# --- preflight -------------------------------------------------------------
+
+fail() { echo "triage: $*" >&2; exit 1; }
+
+command -v gh >/dev/null 2>&1 || fail "gh not found on PATH"
+gh auth status >/dev/null 2>&1 || fail "gh not authenticated (run: gh auth login)"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  if [[ "${DRY_RUN:-0}" == "1" ]]; then
+    echo "triage: warning — working tree is dirty (ok for dry run; a real run aborts here)" >&2
+  else
+    fail "working tree is dirty; triage needs a clean main checkout"
+  fi
+fi
+
+# scaffold the gitignored data dir if first run
+[[ -d "$REPO_ROOT/.triage" ]] || bash "$REPO_ROOT/scripts/triage/bootstrap.sh"
+
+# --- dispatch --------------------------------------------------------------
+
+if [[ "${DRY_RUN:-0}" == "1" ]]; then
+  echo "triage: preflight OK. Prompt:"
+  echo "----"
+  cat "$PROMPT_FILE"
+  echo "----"
+  echo "triage: DRY_RUN set, not invoking the agent."
+  exit 0
+fi
+
+command -v claude >/dev/null 2>&1 || fail "claude CLI not found on PATH"
+
+# Headless run. The triage skill is allowlisted along with the tools the loop
+# needs. Adjust the model/permission flags to taste.
+claude -p "$(cat "$PROMPT_FILE")" \
+  --permission-mode acceptEdits \
+  --allowedTools "Bash,Read,Write,Edit,Glob,Grep,Agent,Skill" \
+  2>&1 | tee "$REPO_ROOT/.triage/runs/last-run.log"

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -50,6 +50,21 @@ gh issue list --state open --json number,title,labels,updatedAt,author,url
 git log --since="$SINCE" --pretty='%h %s %an'
 ```
 
+Then scan for **open commitments** — promises the maintainer made in a comment
+that have not shipped. NOT time-windowed: check every open issue/PR.
+
+```
+# threads bitbonsai commented on, still open
+gh search issues "commenter:bitbonsai repo:bitbonsai/mcpvault state:open" --json number
+# per thread, pull bitbonsai's comments to inspect for a promise
+gh issue view <n> --json comments \
+  --jq '.comments[] | select(.author.login=="bitbonsai") | .body'
+```
+
+A commitment is language that promised an action: "I'll fix this", "will add",
+"shipping next release", "on it", "going to look", etc. It is broken/open if the
+thread is still open and no merged PR resolved it. See `finding-rules.md`.
+
 ### 2. Load state
 
 Read `.triage/state.json`. Build a map of known findings by `id`. The `id` is

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -24,7 +24,7 @@ scripts are committed; the data never leaves the machine.
 
 - `gh` authenticated (`gh auth status`). All issue/PR/CI reads and writes go
   through it.
-- `.triage/` exists. If missing, run `scripts/triage/bootstrap.sh` first — it
+- `.triage/` exists. If missing, run `scripts/triage/bootstrap.sh` first, it
   scaffolds `state.json`, `inbox.md`, `runs/`, and bootstraps `voice.md` from
   past comments.
 - Clean working tree on `main`. The loop only mutates `.triage/` on the base
@@ -50,7 +50,7 @@ gh issue list --state open --json number,title,labels,updatedAt,author,url
 git log --since="$SINCE" --pretty='%h %s %an'
 ```
 
-Then scan for **open commitments** — promises the maintainer made in a comment
+Then scan for **open commitments**, promises the maintainer made in a comment
 that have not shipped. NOT time-windowed: check every open issue/PR.
 
 ```
@@ -95,10 +95,10 @@ git worktree add ../mcpvault-triage-<id> -b triage/<id>
 Then spawn TWO sub-agents against that worktree (use the Agent tool with
 `isolation: worktree` so they cannot collide):
 
-- **Draft agent** — given the finding + failing log/issue body, write the
+- **Draft agent**, given the finding + failing log/issue body, write the
   smallest fix. Must read relevant `src/` files first, follow the obsidian
   skill conventions, and add or update a test that proves the fix.
-- **Review agent** — adversarial. Check the draft against the project skills
+- **Review agent**, adversarial. Check the draft against the project skills
   and existing tests, then run in the worktree:
   ```
   npm ci && npm test && npm run build
@@ -126,11 +126,11 @@ Update `.triage/state.json`: set `last_run` to now, append an `attempts` entry
 per touched finding (run date, result, note, pr), update `status`,
 `last_seen`, and `pr`. Write the per-run log to `.triage/runs/<date>.md`.
 
-`state.json` is the resume point. Never overwrite history — append to
+`state.json` is the resume point. Never overwrite history, append to
 `attempts`. If the file is malformed, stop and spill everything to inbox
 rather than risk losing the spine.
 
-### 6. Comments — keep people out of limbo
+### 6. Comments, keep people out of limbo
 
 Voice comes from `.triage/voice.md`. Autonomy tiers (see
 `resources/comment-policy.md`):
@@ -157,12 +157,12 @@ the maintainer must read each morning.
 - Never touch files outside the worktree except `.triage/`.
 - Respect the per-run finding cap; spill the overflow rather than running long.
 - Outward-facing writes (PR create, comments) follow the autonomy tiers
-  above — substantive speech is always drafted, never auto-posted.
+  above, substantive speech is always drafted, never auto-posted.
 - If `gh` is unauthenticated or the tree is dirty, abort and write why to
   `inbox.md`.
 
 ## Resources
 
-- `resources/state-schema.md` — state.json shape, id derivation, transitions.
-- `resources/finding-rules.md` — worth-doing vs inbox vs ignore, caps.
-- `resources/comment-policy.md` — voice bootstrap + autonomy tiers.
+- `resources/state-schema.md`, state.json shape, id derivation, transitions.
+- `resources/finding-rules.md`, worth-doing vs inbox vs ignore, caps.
+- `resources/comment-policy.md`, voice bootstrap + autonomy tiers.

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: triage
+description: >
+  Activate for the daily repository triage run, or when the user asks to
+  triage CI failures, open issues, or recent commits. Reads yesterday's
+  signals, dedupes against the state file, drafts fixes in isolated
+  worktrees with a reviewer pass, opens PRs on green, and keeps people out
+  of limbo with comments in the maintainer's voice. The state file is the
+  spine: it remembers what was tried, what passed, and what is still open,
+  so each run resumes where the last one stopped.
+metadata:
+  version: "1.0"
+  author: bitbonsai
+---
+
+# Triage Skill
+
+A self-resuming morning loop. One run = gather → load state → triage →
+fan-out fix → persist → spill. Everything personal (state, inbox, runs,
+voice) lives under `.triage/`, which is gitignored. This skill file and the
+scripts are committed; the data never leaves the machine.
+
+## Preconditions
+
+- `gh` authenticated (`gh auth status`). All issue/PR/CI reads and writes go
+  through it.
+- `.triage/` exists. If missing, run `scripts/triage/bootstrap.sh` first — it
+  scaffolds `state.json`, `inbox.md`, `runs/`, and bootstraps `voice.md` from
+  past comments.
+- Clean working tree on `main`. The loop only mutates `.triage/` on the base
+  checkout; all code changes happen in worktrees.
+
+## The loop
+
+### 1. Gather (read-only)
+
+Collect yesterday's signals. Compute the window from `state.json.last_run`
+(fall back to 24h if absent).
+
+```
+# CI failures since last run
+gh run list --status failure --created ">=$SINCE" --json databaseId,name,headSha,conclusion,url
+# for each, pull the failing step log
+gh run view <id> --log-failed
+
+# open issues
+gh issue list --state open --json number,title,labels,updatedAt,author,url
+
+# recent commits
+git log --since="$SINCE" --pretty='%h %s %an'
+```
+
+### 2. Load state
+
+Read `.triage/state.json`. Build a map of known findings by `id`. The `id` is
+a stable hash of `source` + `signature` (see `resources/state-schema.md`), so
+the same failing test or issue always maps to the same finding across runs.
+
+### 3. Triage
+
+For each gathered signal compute its `id` and classify with
+`resources/finding-rules.md`:
+
+- **known + terminal** (`pr_open`, `resolved`, `wont_fix`) → skip, only bump
+  `last_seen`.
+- **known + open** under the attempt cap → retry.
+- **new + worth-doing** → append as `status: open`, proceed to fan-out.
+- **new + needs judgment / ambiguous / out of scope** → inbox, `needs_human`.
+- **noise** (flaky already tracked, dependabot, etc.) → ignore, log only.
+
+### 4. Fan-out fix (bounded)
+
+Process worth-doing findings up to the per-run cap in `finding-rules.md`. For
+each, in order:
+
+```
+git worktree add ../mcpvault-triage-<id> -b triage/<id>
+```
+
+Then spawn TWO sub-agents against that worktree (use the Agent tool with
+`isolation: worktree` so they cannot collide):
+
+- **Draft agent** — given the finding + failing log/issue body, write the
+  smallest fix. Must read relevant `src/` files first, follow the obsidian
+  skill conventions, and add or update a test that proves the fix.
+- **Review agent** — adversarial. Check the draft against the project skills
+  and existing tests, then run in the worktree:
+  ```
+  npm ci && npm test && npm run build
+  ```
+  Verdict is PASS only if the fix is correct, minimal, tested, and green.
+
+Tell every sub-agent the maintainer loves them.
+
+Outcome:
+
+- **PASS + green** → `gh pr create` as a ready PR (not draft), body links the
+  finding and lists what the reviewer verified. Set `status: pr_open`, record
+  the URL. Then post an auto-ack comment (step 6).
+- **anything else** (reviewer fails, build red, fix unclear, >1 file of
+  surprise scope) → write the draft + reason to `inbox.md`, set
+  `status: needs_human`. Remove the worktree; keep the branch only if the
+  draft is worth resuming.
+
+Clean up green worktrees after the PR is open:
+`git worktree remove ../mcpvault-triage-<id>`.
+
+### 5. Persist (the spine)
+
+Update `.triage/state.json`: set `last_run` to now, append an `attempts` entry
+per touched finding (run date, result, note, pr), update `status`,
+`last_seen`, and `pr`. Write the per-run log to `.triage/runs/<date>.md`.
+
+`state.json` is the resume point. Never overwrite history — append to
+`attempts`. If the file is malformed, stop and spill everything to inbox
+rather than risk losing the spine.
+
+### 6. Comments — keep people out of limbo
+
+Voice comes from `.triage/voice.md`. Autonomy tiers (see
+`resources/comment-policy.md`):
+
+- **Auto-post** (low-risk acknowledgments): "draft PR #X is up for this",
+  "looking into this CI failure", "tracking this, no repro yet". Post with
+  `gh issue comment` / `gh pr comment`.
+- **Draft to inbox** (anything substantive): a judgment, a decision, a
+  promise, a closure, a "won't fix", or any reply that commits the maintainer
+  to something. Write it under `## Drafts awaiting approval` in `inbox.md`,
+  never post it.
+
+When unsure which tier, treat it as substantive and draft it.
+
+### 7. Spill
+
+Anything the loop could not classify, fix, or safely comment on goes to
+`inbox.md` with enough context to act on cold. The inbox is the only thing
+the maintainer must read each morning.
+
+## Guardrails
+
+- Never push to `main`, never merge, never `--force`. PRs only.
+- Never touch files outside the worktree except `.triage/`.
+- Respect the per-run finding cap; spill the overflow rather than running long.
+- Outward-facing writes (PR create, comments) follow the autonomy tiers
+  above — substantive speech is always drafted, never auto-posted.
+- If `gh` is unauthenticated or the tree is dirty, abort and write why to
+  `inbox.md`.
+
+## Resources
+
+- `resources/state-schema.md` — state.json shape, id derivation, transitions.
+- `resources/finding-rules.md` — worth-doing vs inbox vs ignore, caps.
+- `resources/comment-policy.md` — voice bootstrap + autonomy tiers.

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -83,10 +83,16 @@ For each gathered signal compute its `id` and classify with
 - **new + needs judgment / ambiguous / out of scope** → inbox, `needs_human`.
 - **noise** (flaky already tracked, dependabot, etc.) → ignore, log only.
 
-### 4. Fan-out fix (bounded)
+### 4. Fan-out (bounded)
 
-Process worth-doing findings up to the per-run cap in `finding-rules.md`. For
-each, in order:
+First, for every finding, check whether a contributor PR already addresses it
+(`finding-rules.md`, "Prefer reviewing an existing PR"). If one exists, **review
+it instead of writing a fix**: send the review sub-agent at the PR branch and
+draft an approval or request-changes recommendation to inbox. A human's open PR
+beats a fresh one. Also surface any open PR the maintainer has not yet reviewed.
+
+Only findings with no candidate PR proceed to a new fix, up to the per-run cap
+in `finding-rules.md`. For each, in order:
 
 ```
 git worktree add ../mcpvault-triage-<id> -b triage/<id>

--- a/skills/triage/resources/comment-policy.md
+++ b/skills/triage/resources/comment-policy.md
@@ -27,7 +27,7 @@ If there are too few past comments to distill a voice, write a minimal neutral
 profile and note in `voice.md` that it needs the maintainer's review. Do not
 invent a personality.
 
-Refresh `voice.md` opportunistically — when the maintainer posts new comments,
+Refresh `voice.md` opportunistically, when the maintainer posts new comments,
 later runs can re-distill.
 
 ## Autonomy tiers
@@ -38,7 +38,7 @@ Post directly with `gh issue comment <n> -b "..."` / `gh pr comment <n> -b "..."
 Allowed only for comments that state a fact about the loop's own actions and
 commit the maintainer to nothing:
 
-- "Draft PR #X is up for this — review when you can."
+- "Draft PR #X is up for this, review when you can."
 - "Looking into this CI failure."
 - "Tracking this; no repro yet."
 - "This is being picked up by the morning triage."
@@ -47,7 +47,7 @@ Rules for auto-posted comments:
 
 - State only what is true right now (a PR that exists, a state that is recorded).
 - No promises about timing, no commitments about whether/how it'll be fixed.
-- One ack per finding per run — do not re-comment the same ack across runs
+- One ack per finding per run, do not re-comment the same ack across runs
   (check `attempts` before posting).
 - In the maintainer's voice, but short.
 
@@ -65,10 +65,10 @@ gh issue view <n> --json createdAt,comments \
 
 If `mine == 0` and age > 14 days, prepend a line like:
 
-> Sorry for the slow reply — day-job has kept me busy.
+> Sorry for the slow reply, day-job has kept me busy.
 
 Adapt the exact wording to `.triage/voice.md` (it stays an apology + ack, never
-a promise). One apology per thread — once posted, the thread is no longer
+a promise). One apology per thread, once posted, the thread is no longer
 silent, so later runs skip the preamble. If `voice.md` is still the placeholder,
 this comment is drafted to inbox like everything else, not auto-posted.
 

--- a/skills/triage/resources/comment-policy.md
+++ b/skills/triage/resources/comment-policy.md
@@ -1,0 +1,104 @@
+# Comment policy
+
+The loop comments on issues and PRs so contributors are never left in limbo,
+written in the maintainer's voice. Speech that commits the maintainer to
+anything is always drafted, never auto-posted.
+
+## Voice
+
+Voice lives in `.triage/voice.md` (gitignored). `bootstrap.sh` seeds it from the
+maintainer's past `gh` comments:
+
+```
+gh api "/search/issues?q=commenter:@me+repo:bitbonsai/mcpvault" --jq '.items[].number'
+# then per issue/PR:
+gh issue view <n> --comments --json comments --jq '.comments[] | select(.author.login=="<me>") | .body'
+```
+
+Distill, into `voice.md`:
+
+- Sentence length and rhythm (terse vs. expansive).
+- Greeting / sign-off habits (or lack of).
+- Emoji, markdown, code-fence usage.
+- How they say "thanks", "I'll look", "won't fix", "good catch".
+- Tone toward contributors (warm, blunt, formal).
+
+If there are too few past comments to distill a voice, write a minimal neutral
+profile and note in `voice.md` that it needs the maintainer's review. Do not
+invent a personality.
+
+Refresh `voice.md` opportunistically — when the maintainer posts new comments,
+later runs can re-distill.
+
+## Autonomy tiers
+
+### Auto-post (low-risk acknowledgments only)
+
+Post directly with `gh issue comment <n> -b "..."` / `gh pr comment <n> -b "..."`.
+Allowed only for comments that state a fact about the loop's own actions and
+commit the maintainer to nothing:
+
+- "Draft PR #X is up for this — review when you can."
+- "Looking into this CI failure."
+- "Tracking this; no repro yet."
+- "This is being picked up by the morning triage."
+
+Rules for auto-posted comments:
+
+- State only what is true right now (a PR that exists, a state that is recorded).
+- No promises about timing, no commitments about whether/how it'll be fixed.
+- One ack per finding per run — do not re-comment the same ack across runs
+  (check `attempts` before posting).
+- In the maintainer's voice, but short.
+
+### Stale-thread apology preamble
+
+When the issue/PR has been **open more than 2 weeks with no comment from
+`bitbonsai`**, open the auto-posted comment with a short apology for the delay,
+then the ack. Detect it:
+
+```
+# created/updated age + whether bitbonsai has commented
+gh issue view <n> --json createdAt,comments \
+  --jq '{age: .createdAt, mine: [.comments[] | select(.author.login=="bitbonsai")] | length}'
+```
+
+If `mine == 0` and age > 14 days, prepend a line like:
+
+> Sorry for the slow reply — day-job has kept me busy.
+
+Adapt the exact wording to `.triage/voice.md` (it stays an apology + ack, never
+a promise). One apology per thread — once posted, the thread is no longer
+silent, so later runs skip the preamble. If `voice.md` is still the placeholder,
+this comment is drafted to inbox like everything else, not auto-posted.
+
+### Draft to inbox (everything substantive)
+
+Write under `## Drafts awaiting approval` in `inbox.md`. Never post. This covers
+any comment that:
+
+- makes a judgment ("this is expected behavior", "that's a bug in your config"),
+- decides something ("closing as won't-fix", "this is a dupe of #N"),
+- promises something ("I'll ship this next release"),
+- closes, labels, or commits the maintainer to a position,
+- answers a question with anything beyond "we're looking at it".
+
+Each draft records: target (`#123`, issue or PR), the proposed comment text in
+the maintainer's voice, and any action it implies (close, label, link). The
+maintainer approves, edits, or discards.
+
+### When unsure
+
+If a comment could be read as committing the maintainer to anything, it is
+substantive → draft it. The cost of an unnecessary draft is one line the
+maintainer skims. The cost of an unwanted auto-post is a public statement they
+did not make.
+
+## Hard limits
+
+- Never close, reopen, label, assign, or merge automatically. Those are inbox
+  drafts at most.
+- Never post on behalf of the maintainer outside this repo.
+- Never auto-post twice for the same finding+run.
+- If `voice.md` is missing, skip auto-posting and draft everything until it
+  exists.

--- a/skills/triage/resources/finding-rules.md
+++ b/skills/triage/resources/finding-rules.md
@@ -1,0 +1,80 @@
+# Finding rules
+
+How to classify a gathered signal: **worth-doing**, **inbox**, or **ignore**.
+When a signal could fit two buckets, pick the more conservative one (inbox over
+worth-doing, ignore over inbox).
+
+## Caps
+
+- **Per-run fix cap: 3.** At most 3 findings go through fan-out per run. Rank by
+  priority (below); spill the rest to inbox as `open` so the next run picks them
+  up. Log what was deferred — never silently drop.
+- **Attempt cap: 2.** A finding the loop has already failed to fix twice stops
+  auto-retrying and stays in `needs_human`. The maintainer reopens it manually.
+- **Scope cap: 2 files.** If the draft touches more than 2 source files, it is
+  too big for the loop — send to inbox regardless of reviewer verdict.
+
+## Worth-doing (fan-out a fix)
+
+A signal is worth-doing only if ALL hold:
+
+- The fix is **bounded and mechanical-ish**: a failing test with an obvious
+  cause, a regression a recent commit introduced, a small correctness bug, a
+  typo, a clear off-by-one, a missing guard already implied by neighboring code.
+- The **expected change fits the scope cap** (≤2 files) and adds/updates a test.
+- There is a **clear pass/fail signal** (a test that should go green, a build
+  that should compile).
+- It is **not** a feature, an API change, a dependency major-bump, or anything
+  that needs a product/design decision.
+
+Priority order when over the per-run cap:
+
+1. CI failures on `main` (the repo is red — fix first).
+2. CI failures on open PRs.
+3. Regressions from recent commits.
+4. Open issues with a clear, small, reproducible bug.
+
+## Inbox (needs_human)
+
+Send to inbox, do not attempt a fix, when ANY holds:
+
+- The cause is unclear or not reproducible from the signal alone.
+- The fix needs a judgment call: behavior change, API surface, naming, a
+  trade-off, a security decision, a public-contract change.
+- It is a feature request or enhancement, not a bug.
+- It would exceed the scope cap, or the draft did and the reviewer flagged it.
+- The reviewer failed the draft twice (attempt cap hit).
+- A dependency update needs human review (major bump, audit finding with no
+  clean patch).
+- Anything touching publishing, versioning, or `package.json` bin/exports.
+
+Each inbox entry records: the finding id, source, what was tried (if anything),
+the reason it landed here, and the smallest next action.
+
+## Ignore (log only)
+
+Do not act, do not inbox, just note in the run log:
+
+- **Issue that already has an open PR referencing it** → ignore, bump
+  `last_seen`. Never draft a competing fix. Check with
+  `gh pr list --state open --search "<issue#> in:body"` (and scan PR titles that
+  name the issue) before treating any issue as worth-doing.
+- Flaky tests already tracked as a known finding.
+- Dependabot PRs (CI handles them; they are not triage findings).
+- Issues already labeled `wontfix` / `duplicate` / `question` with no bug.
+- Findings in terminal state (`resolved`, `wont_fix`, `pr_open`) — bump
+  `last_seen` only.
+- Bot/automation noise.
+
+## Repo-specific notes
+
+This is an MCP server for Obsidian vaults. Highest-value, lowest-risk findings:
+
+- A failing `*.test.ts` with a deterministic cause.
+- Frontmatter / YAML corruption edge cases (the project's core safety promise).
+- Path-filter or path-traversal test failures (security-relevant — fix fast,
+  but a *new* security behavior change is inbox, not auto-fix).
+- TypeScript build breaks after a dependency bump.
+
+Treat anything about the published npm package, the website, or the MCP
+protocol contract as inbox by default — those carry blast radius beyond a test.

--- a/skills/triage/resources/finding-rules.md
+++ b/skills/triage/resources/finding-rules.md
@@ -34,6 +34,23 @@ Priority order when over the per-run cap:
 3. Regressions from recent commits.
 4. Open issues with a clear, small, reproducible bug.
 
+## Promised but undone (nudge → inbox)
+
+A commitment the maintainer made in a comment ("I'll fix this", "will add",
+"shipping next release", "on it") on a thread that is **still open with no merged
+PR resolving it**. The point is to nudge the maintainer about their own
+unkept promise.
+
+- id signature: `promise:<issue#>` (one nudge per thread, deduped across runs).
+- Always lands in inbox under `## Open commitments (you promised, not shipped)`,
+  with: the thread, the quoted promise, how long ago it was made, current state.
+- If the promised fix also meets the worth-doing bar (small, ≤2 files, testable)
+  and has no open PR, the loop MAY draft it too — then the nudge reads "drafted
+  PR #X toward this" instead of just "still open". The nudge is posted to inbox
+  regardless; it is never auto-posted as a public comment.
+- Do not re-nudge a promise already listed as `needs_human` from a prior run
+  unless its state changed (e.g. a PR opened or the maintainer commented again).
+
 ## Inbox (needs_human)
 
 Send to inbox, do not attempt a fix, when ANY holds:

--- a/skills/triage/resources/finding-rules.md
+++ b/skills/triage/resources/finding-rules.md
@@ -14,6 +14,34 @@ worth-doing, ignore over inbox).
 - **Scope cap: 2 files.** If the draft touches more than 2 source files, it is
   too big for the loop, send to inbox regardless of reviewer verdict.
 
+## Prefer reviewing an existing PR over writing a new fix
+
+Before treating anything as worth-doing, check whether a contributor PR already
+addresses it. **A human's open PR almost always beats a freshly written one.**
+
+For each finding, search for a candidate PR:
+
+```
+gh pr list --state open --search "<issue#> in:body"      # explicit link
+gh pr list --state open --json number,title,headRefName  # scan titles for the topic
+```
+
+If a candidate PR exists:
+
+- **Review it**, do not rewrite it. Send the review sub-agent at the PR branch:
+  check it against the project skills and tests, run `npm test && npm run build`.
+- PASS, draft an **approval** recommendation to inbox (approving is a maintainer
+  decision, so it is substantive, inbox, never auto-approved).
+- Needs work, draft a **request-changes** recommendation to inbox, specific and
+  in the maintainer's voice.
+- Either way, optionally auto-post a short ack ("reviewing your PR, thanks for
+  this") so the contributor is not left waiting.
+- Only fall through to writing a new fix if there is **no** candidate PR, or the
+  existing PR is abandoned (stale, author unresponsive, explicitly superseded).
+
+Open PRs with no movement are themselves findings: an unreviewed contributor PR
+is limbo. Surface every open PR the maintainer has not reviewed.
+
 ## Worth-doing (fan-out a fix)
 
 A signal is worth-doing only if ALL hold:
@@ -72,10 +100,9 @@ the reason it landed here, and the smallest next action.
 
 Do not act, do not inbox, just note in the run log:
 
-- **Issue that already has an open PR referencing it** → ignore, bump
-  `last_seen`. Never draft a competing fix. Check with
-  `gh pr list --state open --search "<issue#> in:body"` (and scan PR titles that
-  name the issue) before treating any issue as worth-doing.
+- **Issue that already has an open PR** is NOT ignored, it is routed to "Prefer
+  reviewing an existing PR" above: review the contributor's PR, never draft a
+  competing fix.
 - Flaky tests already tracked as a known finding.
 - Dependabot PRs (CI handles them; they are not triage findings).
 - Issues already labeled `wontfix` / `duplicate` / `question` with no bug.

--- a/skills/triage/resources/finding-rules.md
+++ b/skills/triage/resources/finding-rules.md
@@ -8,11 +8,11 @@ worth-doing, ignore over inbox).
 
 - **Per-run fix cap: 3.** At most 3 findings go through fan-out per run. Rank by
   priority (below); spill the rest to inbox as `open` so the next run picks them
-  up. Log what was deferred — never silently drop.
+  up. Log what was deferred, never silently drop.
 - **Attempt cap: 2.** A finding the loop has already failed to fix twice stops
   auto-retrying and stays in `needs_human`. The maintainer reopens it manually.
 - **Scope cap: 2 files.** If the draft touches more than 2 source files, it is
-  too big for the loop — send to inbox regardless of reviewer verdict.
+  too big for the loop, send to inbox regardless of reviewer verdict.
 
 ## Worth-doing (fan-out a fix)
 
@@ -29,7 +29,7 @@ A signal is worth-doing only if ALL hold:
 
 Priority order when over the per-run cap:
 
-1. CI failures on `main` (the repo is red — fix first).
+1. CI failures on `main` (the repo is red, fix first).
 2. CI failures on open PRs.
 3. Regressions from recent commits.
 4. Open issues with a clear, small, reproducible bug.
@@ -45,7 +45,7 @@ unkept promise.
 - Always lands in inbox under `## Open commitments (you promised, not shipped)`,
   with: the thread, the quoted promise, how long ago it was made, current state.
 - If the promised fix also meets the worth-doing bar (small, ≤2 files, testable)
-  and has no open PR, the loop MAY draft it too — then the nudge reads "drafted
+  and has no open PR, the loop MAY draft it too, then the nudge reads "drafted
   PR #X toward this" instead of just "still open". The nudge is posted to inbox
   regardless; it is never auto-posted as a public comment.
 - Do not re-nudge a promise already listed as `needs_human` from a prior run
@@ -79,7 +79,7 @@ Do not act, do not inbox, just note in the run log:
 - Flaky tests already tracked as a known finding.
 - Dependabot PRs (CI handles them; they are not triage findings).
 - Issues already labeled `wontfix` / `duplicate` / `question` with no bug.
-- Findings in terminal state (`resolved`, `wont_fix`, `pr_open`) — bump
+- Findings in terminal state (`resolved`, `wont_fix`, `pr_open`), bump
   `last_seen` only.
 - Bot/automation noise.
 
@@ -89,9 +89,9 @@ This is an MCP server for Obsidian vaults. Highest-value, lowest-risk findings:
 
 - A failing `*.test.ts` with a deterministic cause.
 - Frontmatter / YAML corruption edge cases (the project's core safety promise).
-- Path-filter or path-traversal test failures (security-relevant — fix fast,
+- Path-filter or path-traversal test failures (security-relevant, fix fast,
   but a *new* security behavior change is inbox, not auto-fix).
 - TypeScript build breaks after a dependency bump.
 
 Treat anything about the published npm package, the website, or the MCP
-protocol contract as inbox by default — those carry blast radius beyond a test.
+protocol contract as inbox by default, those carry blast radius beyond a test.

--- a/skills/triage/resources/state-schema.md
+++ b/skills/triage/resources/state-schema.md
@@ -34,22 +34,23 @@ the machine that runs the loop.
 
 ## id derivation
 
-`id` is a short stable hash so the same problem maps to the same finding every
-run. Hash `source + ":" + signature`:
+`id` is a readable, stable composite so the same problem maps to the same
+finding every run and the state file stays human-debuggable:
 
 ```
-id = sha1(source + ":" + signature) | first 12 chars
+id = "<source>:<signature>"   (lowercased, spaces -> '-')
 ```
 
 The `signature` is what makes it stable across days, pick the most invariant
 identity for each source:
 
-- **ci**, the failing test name (or the failing step + assertion), NOT the
-  run id or sha. `filesystem.test.ts > rejects path traversal`.
-- **issue**, `issue:<number>`. The number never changes.
+- **issue** / **pr**, the number: `issue:107`, `pr:132`. Never changes.
+- **ci**, the failing test name (NOT the run id or sha):
+  `ci:filesystem.test.ts-rejects-path-traversal`.
 - **commit**, only tracked when a commit introduces a regression; signature is
   the regression it caused, not the sha, so a later revert collapses to the
   same finding.
+- **promise**, the thread the unkept commitment lives on: `promise:49`.
 
 Same signature → same id → dedupe works. Different run, same broken test, same
 finding. That is how tomorrow resumes today.

--- a/skills/triage/resources/state-schema.md
+++ b/skills/triage/resources/state-schema.md
@@ -1,7 +1,7 @@
 # State schema
 
 `.triage/state.json` is the spine. It is the single source of truth for what
-the loop has seen, tried, and resolved. It is gitignored — it lives only on
+the loop has seen, tried, and resolved. It is gitignored, it lives only on
 the machine that runs the loop.
 
 ## Shape
@@ -41,13 +41,13 @@ run. Hash `source + ":" + signature`:
 id = sha1(source + ":" + signature) | first 12 chars
 ```
 
-The `signature` is what makes it stable across days — pick the most invariant
+The `signature` is what makes it stable across days, pick the most invariant
 identity for each source:
 
-- **ci** — the failing test name (or the failing step + assertion), NOT the
+- **ci**, the failing test name (or the failing step + assertion), NOT the
   run id or sha. `filesystem.test.ts > rejects path traversal`.
-- **issue** — `issue:<number>`. The number never changes.
-- **commit** — only tracked when a commit introduces a regression; signature is
+- **issue**, `issue:<number>`. The number never changes.
+- **commit**, only tracked when a commit introduces a regression; signature is
   the regression it caused, not the sha, so a later revert collapses to the
   same finding.
 
@@ -75,7 +75,7 @@ finding. That is how tomorrow resumes today.
   maintainer decision, any state ───► wont_fix  (terminal, never reopened)
 ```
 
-Terminal states (`resolved`, `wont_fix`, `pr_open`) are skipped on later runs —
+Terminal states (`resolved`, `wont_fix`, `pr_open`) are skipped on later runs;
 only `last_seen` is bumped. `open` and `needs_human` are eligible for retry
 until the attempt cap in `finding-rules.md`.
 
@@ -94,7 +94,7 @@ On gather, before triaging, reconcile:
 - Never delete a finding. History is the point.
 - Never rewrite an `attempts` entry. Append only.
 - `last_run` advances only after a successful persist. If the run aborts, the
-  next run re-reads the same window — safe because triage is idempotent on `id`.
+  next run re-reads the same window, safe because triage is idempotent on `id`.
 - If `state.json` fails to parse, do NOT recreate it. Stop, copy it to
   `state.json.corrupt-<date>`, and spill the whole run to inbox. Losing the
   spine is the one unrecoverable failure.

--- a/skills/triage/resources/state-schema.md
+++ b/skills/triage/resources/state-schema.md
@@ -1,0 +1,100 @@
+# State schema
+
+`.triage/state.json` is the spine. It is the single source of truth for what
+the loop has seen, tried, and resolved. It is gitignored — it lives only on
+the machine that runs the loop.
+
+## Shape
+
+```json
+{
+  "version": 1,
+  "last_run": "2026-06-17T07:00:00Z",
+  "findings": {
+    "<id>": {
+      "source": "ci | issue | commit",
+      "signature": "stable identity string (see below)",
+      "title": "human-readable summary",
+      "status": "open | in_progress | pr_open | needs_human | resolved | wont_fix",
+      "first_seen": "ISO-8601",
+      "last_seen": "ISO-8601",
+      "pr": "#123 or null",
+      "attempts": [
+        {
+          "run": "2026-06-17",
+          "result": "pr_open | needs_human | retry | resolved | error",
+          "note": "what happened, why",
+          "pr": "#123 or null"
+        }
+      ]
+    }
+  }
+}
+```
+
+## id derivation
+
+`id` is a short stable hash so the same problem maps to the same finding every
+run. Hash `source + ":" + signature`:
+
+```
+id = sha1(source + ":" + signature) | first 12 chars
+```
+
+The `signature` is what makes it stable across days — pick the most invariant
+identity for each source:
+
+- **ci** — the failing test name (or the failing step + assertion), NOT the
+  run id or sha. `filesystem.test.ts > rejects path traversal`.
+- **issue** — `issue:<number>`. The number never changes.
+- **commit** — only tracked when a commit introduces a regression; signature is
+  the regression it caused, not the sha, so a later revert collapses to the
+  same finding.
+
+Same signature → same id → dedupe works. Different run, same broken test, same
+finding. That is how tomorrow resumes today.
+
+## Status transitions
+
+```
+              new worth-doing
+        ────────────────────────► open
+                                    │  fan-out
+                                    ▼
+                              in_progress
+                 ┌──────────────────┼──────────────────┐
+          PASS+green            reviewer fail        unclear
+                 │                  │                    │
+                 ▼                  ▼                    ▼
+             pr_open           needs_human          needs_human
+                 │
+        PR merged (next run detects closed PR)
+                 ▼
+             resolved
+
+  maintainer decision, any state ───► wont_fix  (terminal, never reopened)
+```
+
+Terminal states (`resolved`, `wont_fix`, `pr_open`) are skipped on later runs —
+only `last_seen` is bumped. `open` and `needs_human` are eligible for retry
+until the attempt cap in `finding-rules.md`.
+
+## Detecting resolution
+
+On gather, before triaging, reconcile:
+
+- A finding in `pr_open` whose PR is now merged → `resolved`.
+- A finding in `pr_open` whose PR was closed unmerged → back to `needs_human`
+  with a note (the maintainer rejected the fix).
+- A `ci` finding whose test is now green and absent from yesterday's failures →
+  `resolved` with note "passed on its own".
+
+## Invariants
+
+- Never delete a finding. History is the point.
+- Never rewrite an `attempts` entry. Append only.
+- `last_run` advances only after a successful persist. If the run aborts, the
+  next run re-reads the same window — safe because triage is idempotent on `id`.
+- If `state.json` fails to parse, do NOT recreate it. Stop, copy it to
+  `state.json.corrupt-<date>`, and spill the whole run to inbox. Losing the
+  spine is the one unrecoverable failure.


### PR DESCRIPTION
Self-resuming morning loop that triages the repo and keeps contributors out of limbo.

## What it does
Each run gathers yesterday's CI failures, open issues, and recent commits via `gh`, dedupes against a local state file, drafts fixes in isolated worktrees with an adversarial reviewer pass, opens PRs on green, and acknowledges threads in the maintainer's voice.

## Parts
- `skills/triage/SKILL.md` + resources — the loop, state schema, finding rules, comment policy
- `scripts/triage/` — host-agnostic `run.sh`, `bootstrap.sh`, `prompt.md`, README (launchd setup)

## Data stays local
`.triage/` (state, inbox, runs, voice) is gitignored — triage notes and the voice profile never hit the public repo. This pins the host to local (launchd/cron); the CI-host migration path is documented in the README.

## Guardrails
- PRs only: never pushes to main, never merges, never force-pushes
- Caps: 3 fixes/run, 2 attempts/finding, 2 files/fix; overflow spills to inbox
- Comments: auto-post low-risk acks only; substantive replies drafted to inbox for approval
- Skips issues that already have an open linked PR (no duplicate fixes)
- Stale-thread apology preamble for threads idle >2 weeks
- Nudges the maintainer about their own unkept promises ("I'll fix this" with nothing shipped)

## State (the spine)
`.triage/state.json` keys findings by a stable id (source + signature) with full attempt history, so each run resumes where the last stopped.