### PR TITLE
test: lock #116 frontmatter formatting preservation

### DIFF
--- a/src/frontmatter.test.ts
+++ b/src/frontmatter.test.ts
@@ -150,6 +150,30 @@ people:
   expect(result).toContain('"[[Bob]]"');
 });
 
+test("update frontmatter does not re-quote unmodified plain dates or change quote style (#116)", () => {
+  const content = `---
+created: 2026-04-23
+tags:
+  - type/meeting
+project: abc
+attendees:
+  - "[[John-Brown]]"
+summary: Some summary text
+---
+Body text here.`;
+
+  const result = handler.updateFrontmatter(content, { status: "active" });
+
+  // Plain date stays plain, not single-quoted
+  expect(result).toContain("created: 2026-04-23");
+  expect(result).not.toContain("created: '2026-04-23'");
+  // Double-quoted wikilink keeps double quotes, not converted to single
+  expect(result).toContain('"[[John-Brown]]"');
+  expect(result).not.toContain("'[[John-Brown]]'");
+  // The new field is added
+  expect(result).toContain("status: active");
+});
+
 describe("parseFrontmatter", () => {
   test("returns undefined for null and undefined", () => {
     expect(parseFrontmatter(null)).toBeUndefined();


### PR DESCRIPTION
Adds a regression test for #116: `update_frontmatter` must not re-quote unmodified plain dates (`created: 2026-04-23`) or convert double-quoted strings to single-quoted (`"[[John-Brown]]"`) on fields outside the update payload. Already fixed by the AST-aware `preserveStringify` (6e16b48, shipped in 0.11.3); this test guards against regression. Test-only, no version bump.