### PR TITLE
fix: defensive vault-prefix stripping in path resolution

### DIFF
--- a/src/filesystem.test.ts
+++ b/src/filesystem.test.ts
@@ -2,8 +2,8 @@ import { test, expect, beforeEach, afterEach, describe } from "vitest";
 import { FileSystemService, classifyWriteError } from "./filesystem.js";
 import { PathFilter } from "./pathfilter.js";
 import { writeFile, readFile, mkdir, mkdtemp, rm, symlink } from "fs/promises";
-import { join } from "path";
-import { tmpdir } from "os";
+import { join, relative } from "path";
+import { tmpdir, homedir } from "os";
 
 let testVaultPath: string;
 let fileSystem: FileSystemService;
@@ -874,6 +874,57 @@ test("path traversal with .. is blocked", async () => {
 test("path traversal with nested .. is blocked", async () => {
   await expect(fileSystem.readNote("folder/../../outside.md"))
     .rejects.toThrow(/Path traversal not allowed/);
+});
+
+// ============================================================================
+// DEFENSIVE VAULT-PREFIX STRIPPING
+// ============================================================================
+
+test("path containing vault prefix is resolved correctly", async () => {
+  const testPath = "wiki/note.md";
+  const content = "# Note\n\nSome content here.";
+
+  await mkdir(join(testVaultPath, "wiki"), { recursive: true });
+  await writeFile(join(testVaultPath, testPath), content);
+
+  // Simulate a client passing an absolute path that includes the vault prefix.
+  // Use the resolved vault path (realpathSync) since that's what FileSystemService stores.
+  const resolvedVaultPath = fileSystem.getVaultPath();
+  const absolutePath = resolvedVaultPath + "/" + testPath;
+  const note = await fileSystem.readNote(absolutePath);
+
+  expect(note.content).toContain("Some content here.");
+});
+
+test("path containing vault prefix without trailing slash is resolved correctly", async () => {
+  const content = "# Root Note\n\nRoot content.";
+  await writeFile(join(testVaultPath, "root-note.md"), content);
+
+  const resolvedVaultPath = fileSystem.getVaultPath();
+  const absolutePath = resolvedVaultPath + "/root-note.md";
+  const note = await fileSystem.readNote(absolutePath);
+
+  expect(note.content).toContain("Root content.");
+});
+
+test("path with tilde vault prefix is resolved correctly", async () => {
+  const resolvedVaultPath = fileSystem.getVaultPath();
+  const home = homedir();
+
+  // Only run this test if the vault path is under the home directory
+  if (!resolvedVaultPath.startsWith(home)) {
+    return;
+  }
+
+  const content = "# Tilde Note\n\nTilde content.";
+  await writeFile(join(testVaultPath, "tilde-note.md"), content);
+
+  // Construct a ~/... path to the file
+  const relativeToHome = relative(home, resolvedVaultPath);
+  const tildePath = "~/" + relativeToHome + "/tilde-note.md";
+  const note = await fileSystem.readNote(tildePath);
+
+  expect(note.content).toContain("Tilde content.");
 });
 
 // ============================================================================

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -1,4 +1,5 @@
 import { join, resolve, relative, dirname } from 'path';
+import { homedir } from 'os';
 import { readdir, stat, readFile, writeFile, unlink, mkdir, access, rename, copyFile } from 'node:fs/promises';
 import { constants, realpathSync } from 'node:fs';
 import trash from 'trash';
@@ -55,19 +56,35 @@ export class FileSystemService {
     this.frontmatterHandler = frontmatterHandler || new FrontmatterHandler();
   }
 
-  private resolvePath(relativePath: string): string {
-    // Handle undefined or null path
-    if (!relativePath) {
-      relativePath = '';
+  /**
+   * Normalize an incoming path to be vault-relative. Strips leading slashes
+   * and the vault path prefix when a caller accidentally passes an absolute path
+   * (e.g. "/Users/me/vault/wiki/note.md" instead of "wiki/note.md").
+   */
+  private normalizePath(inputPath: string): string {
+    if (!inputPath) return '';
+    let p = inputPath.trim();
+    // Expand ~ to home directory so "~/vault/note.md" can be matched
+    if (p.startsWith('~/') || p === '~') {
+      p = p.replace('~', homedir());
     }
+    // Normalize path separators for cross-platform comparison (Windows backslashes)
+    const normalized = p.replace(/\\/g, '/');
+    const vaultPrefix = this.vaultPath.replace(/\\/g, '/');
+    // Strip vault path prefix before stripping leading slash, so absolute paths
+    // like "/Users/me/vault/wiki/note.md" are handled correctly.
+    if (normalized.startsWith(vaultPrefix + '/')) {
+      p = normalized.slice(vaultPrefix.length + 1);
+    } else if (normalized === vaultPrefix) {
+      p = '';
+    } else if (p.startsWith('/')) {
+      p = p.slice(1);
+    }
+    return p;
+  }
 
-    // Trim whitespace from path
-    relativePath = relativePath.trim();
-
-    // Normalize and resolve the path within the vault
-    const normalizedPath = relativePath.startsWith('/')
-      ? relativePath.slice(1)
-      : relativePath;
+  private resolvePath(relativePath: string): string {
+    const normalizedPath = this.normalizePath(relativePath);
 
     const fullPath = resolve(join(this.vaultPath, normalizedPath));
 
@@ -117,6 +134,7 @@ export class FileSystemService {
   }
 
   async readNote(path: string): Promise<ParsedNote> {
+    path = this.normalizePath(path);
     const fullPath = this.resolvePath(path);
 
     if (!this.pathFilter.isAllowed(path)) {
@@ -149,7 +167,8 @@ export class FileSystemService {
   }
 
   async writeNote(params: NoteWriteParams): Promise<void> {
-    const { path, content, frontmatter, mode = 'overwrite' } = params;
+    const { content, frontmatter, mode = 'overwrite' } = params;
+    const path = this.normalizePath(params.path);
     const fullPath = this.resolvePath(path);
 
     if (!this.pathFilter.isAllowed(path)) {
@@ -224,7 +243,8 @@ export class FileSystemService {
   }
 
   async patchNote(params: PatchNoteParams): Promise<PatchNoteResult> {
-    const { path, oldString, newString, replaceAll = false } = params;
+    const { oldString, newString, replaceAll = false } = params;
+    const path = this.normalizePath(params.path);
 
     if (!this.pathFilter.isAllowed(path)) {
       return {
@@ -315,8 +335,8 @@ export class FileSystemService {
   }
 
   async listDirectory(path: string = ''): Promise<DirectoryListing> {
-    // Normalize path: treat '.' as root directory
-    const normalizedPath = path === '.' ? '' : path;
+    // Normalize path: treat '.' as root directory, strip vault prefix
+    const normalizedPath = path === '.' ? '' : this.normalizePath(path);
     const fullPath = this.resolvePath(normalizedPath);
 
     try {
@@ -377,6 +397,7 @@ export class FileSystemService {
   }
 
   async exists(path: string): Promise<boolean> {
+    path = this.normalizePath(path);
     const fullPath = this.resolvePath(path);
 
     if (!this.pathFilter.isAllowed(path)) {
@@ -392,6 +413,7 @@ export class FileSystemService {
   }
 
   async isDirectory(path: string): Promise<boolean> {
+    path = this.normalizePath(path);
     const fullPath = this.resolvePath(path);
 
     if (!this.pathFilter.isAllowed(path)) {
@@ -407,7 +429,9 @@ export class FileSystemService {
   }
 
   async deleteNote(params: DeleteNoteParams): Promise<DeleteResult> {
-    const { path, confirmPath, trashMode = 'none' } = params;
+    const { trashMode = 'none' } = params;
+    const path = this.normalizePath(params.path);
+    const confirmPath = this.normalizePath(params.confirmPath);
 
     // Confirmation check - paths must match exactly
     if (path !== confirmPath) {
@@ -512,7 +536,9 @@ export class FileSystemService {
   }
 
   async moveNote(params: MoveNoteParams): Promise<MoveResult> {
-    const { oldPath, newPath, overwrite = false } = params;
+    const { overwrite = false } = params;
+    const oldPath = this.normalizePath(params.oldPath);
+    const newPath = this.normalizePath(params.newPath);
 
     if (!this.pathFilter.isAllowed(oldPath)) {
       return {
@@ -596,7 +622,11 @@ export class FileSystemService {
   }
 
   async moveFile(params: MoveFileParams): Promise<MoveResult> {
-    const { oldPath, newPath, confirmOldPath, confirmNewPath, overwrite = false } = params;
+    const { overwrite = false } = params;
+    const oldPath = this.normalizePath(params.oldPath);
+    const newPath = this.normalizePath(params.newPath);
+    const confirmOldPath = this.normalizePath(params.confirmOldPath);
+    const confirmNewPath = this.normalizePath(params.confirmNewPath);
 
     if (oldPath !== confirmOldPath || newPath !== confirmNewPath) {
       return {
@@ -728,7 +758,8 @@ export class FileSystemService {
     }
 
     const results = await Promise.allSettled(
-      paths.map(async (path) => {
+      paths.map(async (rawPath) => {
+        const path = this.normalizePath(rawPath);
         if (!this.pathFilter.isAllowed(path)) {
           throw new Error(`Access denied: ${path}. This path is restricted (system files like .obsidian, .git, and dotfiles are not accessible).`);
         }
@@ -769,7 +800,8 @@ export class FileSystemService {
   }
 
   async updateFrontmatter(params: UpdateFrontmatterParams): Promise<void> {
-    const { path, frontmatter, merge = true } = params;
+    const { frontmatter, merge = true } = params;
+    const path = this.normalizePath(params.path);
 
     if (!this.pathFilter.isAllowed(path)) {
       throw new Error(`Access denied: ${path}. This path is restricted (system files like .obsidian, .git, and dotfiles are not accessible).`);
@@ -807,7 +839,8 @@ export class FileSystemService {
 
   async getNotesInfo(paths: string[]): Promise<NoteInfo[]> {
     const results = await Promise.allSettled(
-      paths.map(async (path): Promise<NoteInfo> => {
+      paths.map(async (rawPath): Promise<NoteInfo> => {
+        const path = this.normalizePath(rawPath);
         if (!this.pathFilter.isAllowed(path)) {
           throw new Error(`Access denied: ${path}. This path is restricted (system files like .obsidian, .git, and dotfiles are not accessible).`);
         }
@@ -849,7 +882,8 @@ export class FileSystemService {
   }
 
   async manageTags(params: TagManagementParams): Promise<TagManagementResult> {
-    const { path, operation, tags = [] } = params;
+    const { operation, tags = [] } = params;
+    const path = this.normalizePath(params.path);
 
     if (!this.pathFilter.isAllowed(path)) {
       return {


### PR DESCRIPTION
Fixes #122

## Summary

When an MCP client passes paths with the vault prefix included — absolute (`/Users/me/vault/wiki/note.md`), tilde (`~/vault/wiki/note.md`), or Windows-style (`C:\Users\me\vault\wiki\note.md`) — instead of vault-relative `wiki/note.md`, the server joins it with the vault root, producing a broken double path like `/Users/me/vault/~/vault/wiki/note.md`.

This is a common mistake across AI agents (Claude Code, Claude Desktop, etc.) that resolve paths internally before passing them to MCP tools.

## Changes

- Adds `normalizePath()` helper that expands `~`, normalizes path separators (`\` → `/` for Windows), and strips vault path prefix from incoming paths
- Applied across all public methods (`readNote`, `writeNote`, `patchNote`, `deleteNote`, `moveNote`, `moveFile`, `listDirectory`, `exists`, `isDirectory`, `readMultipleNotes`, `updateFrontmatter`, `getNotesInfo`, `manageTags`)
- No behavior change for correctly formed vault-relative paths

## Test plan

- [x] 3 new tests: absolute path prefix, relative path prefix, tilde path prefix
- [x] All 208 tests pass (205 existing + 3 new) — rebased onto current main
- [x] Cross-platform: backslash normalization for Windows paths

---
*Rebased from #119 onto current main.*