### PR TITLE
fix: exit when stdio transport closes (#159)

### DIFF
--- a/dist/server.js
+++ b/dist/server.js
@@ -49,3 +49,23 @@ const vaultPath = resolve(vaultPathArg || process.cwd());
 const server = createServer(vaultPath, { version: VERSION });
 const transport = new StdioServerTransport();
 await server.connect(transport);
+// Exit when the client disconnects (stdin EOF) or the process is asked to
+// terminate. Hosts that don't send an MCP shutdown request otherwise leave
+// this process running forever, orphaned once stdin closes (#159).
+let isShuttingDown = false;
+async function shutdown() {
+    if (isShuttingDown)
+        return;
+    isShuttingDown = true;
+    try {
+        await server.close();
+    }
+    catch {
+        // Best-effort: exit regardless of transport close errors.
+    }
+    process.exit(0);
+}
+process.stdin.on("end", shutdown);
+process.stdin.on("close", shutdown);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bitbonsai/mcpvault",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bitbonsai/mcpvault",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.20.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bitbonsai/mcpvault",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant",
   "homepage": "https://mcpvault.org",
   "author": "bitbonsai",

--- a/server.ts
+++ b/server.ts
@@ -58,3 +58,23 @@ const vaultPath = resolve(vaultPathArg || process.cwd());
 const server = createServer(vaultPath, { version: VERSION });
 const transport = new StdioServerTransport();
 await server.connect(transport);
+
+// Exit when the client disconnects (stdin EOF) or the process is asked to
+// terminate. Hosts that don't send an MCP shutdown request otherwise leave
+// this process running forever, orphaned once stdin closes (#159).
+let isShuttingDown = false;
+async function shutdown() {
+  if (isShuttingDown) return;
+  isShuttingDown = true;
+  try {
+    await server.close();
+  } catch {
+    // Best-effort: exit regardless of transport close errors.
+  }
+  process.exit(0);
+}
+
+process.stdin.on("end", shutdown);
+process.stdin.on("close", shutdown);
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);

--- a/src/shutdown.test.ts
+++ b/src/shutdown.test.ts
@@ -1,0 +1,73 @@
+import { test, expect } from "vitest";
+import { spawn, ChildProcessWithoutNullStreams } from "child_process";
+import { mkdtemp, rm } from "fs/promises";
+import { tmpdir } from "os";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+// Issue #159: the stdio server never exited when its transport closed
+// (client disconnect, host with no MCP lifecycle controls), leaving
+// orphaned processes behind. These tests spawn the real entry point and
+// verify it exits promptly on stdin EOF and on termination signals.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(__dirname, "..");
+// Exercise the actual published entry point (dist/server.js), which is what
+// real MCP hosts spawn. Requires `npm run build` to have run first.
+const builtServer = join(repoRoot, "dist", "server.js");
+
+async function spawnServer(vaultPath: string): Promise<ChildProcessWithoutNullStreams> {
+  return spawn(process.execPath, [builtServer, vaultPath], {
+    cwd: repoRoot,
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+}
+
+function waitForExit(child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<number | null> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`process did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code);
+    });
+  });
+}
+
+test("stdio server exits when the client closes stdin (EOF)", async () => {
+  const vaultPath = await mkdtemp(join(tmpdir(), "mcpvault-shutdown-"));
+  const child = await spawnServer(vaultPath);
+
+  try {
+    const exitPromise = waitForExit(child, 4000);
+    // Give the server a moment to finish booting before simulating the
+    // client disconnecting.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    child.stdin.end();
+
+    const exitCode = await exitPromise;
+    expect(exitCode).toBe(0);
+  } finally {
+    if (child.exitCode === null) child.kill("SIGKILL");
+    await rm(vaultPath, { recursive: true }).catch(() => {});
+  }
+}, 10000);
+
+test("stdio server exits on SIGTERM", async () => {
+  const vaultPath = await mkdtemp(join(tmpdir(), "mcpvault-shutdown-"));
+  const child = await spawnServer(vaultPath);
+
+  try {
+    const exitPromise = waitForExit(child, 4000);
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    child.kill("SIGTERM");
+
+    const exitCode = await exitPromise;
+    expect(exitCode).toBe(0);
+  } finally {
+    if (child.exitCode === null) child.kill("SIGKILL");
+    await rm(vaultPath, { recursive: true }).catch(() => {});
+  }
+}, 10000);


### PR DESCRIPTION
Fixes #159.

The stdio server had no shutdown path: `main()` connected the transport and the process stayed alive after the host disconnected, orphaning instances (reporter observed 26 across two vaults; some hosts expose no MCP lifecycle controls, so self-termination is the only self-healing route).

## What this does
- `server.ts` (entry point only — `createServer()` library API untouched): on stdin `end`/`close`, `SIGTERM`, or `SIGINT`, run `server.close()` then `process.exit(0)`, with a dedupe guard for overlapping events.
- New integration test `src/shutdown.test.ts`: spawns the built server, closes stdin → asserts exit 0 within 5s; sends SIGTERM → asserts exit 0.
- Version 0.12.4 → 0.12.5, dist rebuilt.

## Reviewer verified
- Full suite: 245 passed (243 existing + 2 new), build green, `npm ci` clean.
- Handlers install only when the binary runs — InMemoryTransport/library consumers unaffected.
- No premature-exit path found for tty/inherit stdin; EOF fires only on real disconnect.
- dist in sync with src (rebuilt and diffed).

Thanks @rexplx for the precise report and the suggested fix this builds on.

