### PR TITLE
chore: migrate tsconfig to nodenext for TypeScript 7 (unblocks #157)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,8 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "es2022",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "types": ["node"],
     "lib": ["es2022"],
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Dependabot's TypeScript 7 bump (#157) fails with `TS5108: Option 'moduleResolution=node10' has been removed`. This migrates the config under the pinned TS 6.0.3 so the bump can land cleanly after.

Single-file change, `tsconfig.json`:
- `module`/`moduleResolution` → `nodenext` (the correct pairing for a Node ESM package; imports already use `.js` specifiers).
- Drops `ignoreDeprecations: "6.0"`, which only existed to silence the node10 deprecation.

No source changes were needed — the codebase compiles clean under nodenext as-is. dist output is byte-identical, so no rebuild, no version bump, lockfile untouched.

Verified: 243 tests + build green under pinned TS 6.0.3, and `tsc --noEmit` passes under TypeScript 7.0.2. After this merges, #157 should rebase green.
