### PR TITLE
Add --allowed-extensions and --append-only flags; make note writes atomic and serialized

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ npm start ./Vault
 | Flag | Description |
 | --- | --- |
 | `--allowed-extensions=<ext,...>` | Comma-separated extra file extensions to permit on read/write, additive to the built-in defaults (`.md`, `.markdown`, `.txt`, `.base`, `.canvas`). Leading dot optional. Example: `--allowed-extensions=.html,.csv,.json`. |
+| `--append-only=<name,...>` | Comma-separated basenames refused for whole-file overwrite via `write_note` (e.g. `log.md`); clients must use `mode: "append"` or `"prepend"`. Off by default. Guards logs/journals an AI client might otherwise clobber with a stale-read overwrite. |
 
 ### AI Client Configuration
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,12 @@ npm start /path/to/your/obsidian/vault
 npm start ./Vault
 ```
 
+### CLI Options
+
+| Flag | Description |
+| --- | --- |
+| `--allowed-extensions=<ext,...>` | Comma-separated extra file extensions to permit on read/write, additive to the built-in defaults (`.md`, `.markdown`, `.txt`, `.base`, `.canvas`). Leading dot optional. Example: `--allowed-extensions=.html,.csv,.json`. |
+
 ### AI Client Configuration
 
 #### Claude Desktop

--- a/server.ts
+++ b/server.ts
@@ -3,7 +3,7 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./src/createServer.js";
 import { PathFilter } from "./src/pathfilter.js";
-import { parseAllowedExtensions, stripKnownFlags } from "./src/cli.js";
+import { parseAllowedExtensions, parseAppendOnly, stripKnownFlags } from "./src/cli.js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join, resolve } from "path";
@@ -32,7 +32,7 @@ mcpvault v${VERSION}
 Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant
 
 Usage:
-  npx @bitbonsai/mcpvault [vault-path] [--allowed-extensions=ext1,ext2,...]
+  npx @bitbonsai/mcpvault [vault-path] [--allowed-extensions=ext,...] [--append-only=name,...]
 
 Arguments:
   [vault-path]    Optional path to your Obsidian vault directory
@@ -45,6 +45,9 @@ Options:
                             read/write (e.g. ".html,.csv,.json"). Additive to the
                             built-in defaults (.md, .markdown, .txt, .base, .canvas).
                             Leading dot optional.
+  --append-only=...         Comma-separated basenames refused for whole-file
+                            overwrite (e.g. "log.md"); clients must use
+                            mode:'append' or mode:'prepend'. Off by default.
 
 Examples:
   npx @bitbonsai/mcpvault
@@ -57,6 +60,7 @@ Examples:
 
 // Parse recognized flags, then treat the remaining positional args as the vault path.
 const allowedExtensions = parseAllowedExtensions(cliArgs);
+const appendOnly = parseAppendOnly(cliArgs);
 const positionalArgs = stripKnownFlags(cliArgs);
 
 // Join trailing args to support vault paths with spaces.
@@ -73,6 +77,7 @@ const pathFilter = allowedExtensions
 const server = createServer(vaultPath, {
   version: VERSION,
   ...(pathFilter && { pathFilter }),
+  ...(appendOnly && { appendOnly }),
 });
 const transport = new StdioServerTransport();
 await server.connect(transport);

--- a/server.ts
+++ b/server.ts
@@ -2,6 +2,8 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./src/createServer.js";
+import { PathFilter } from "./src/pathfilter.js";
+import { parseAllowedExtensions, stripKnownFlags } from "./src/cli.js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join, resolve } from "path";
@@ -30,32 +32,48 @@ mcpvault v${VERSION}
 Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant
 
 Usage:
-  npx @bitbonsai/mcpvault [vault-path]
+  npx @bitbonsai/mcpvault [vault-path] [--allowed-extensions=ext1,ext2,...]
 
 Arguments:
   [vault-path]    Optional path to your Obsidian vault directory
                   Defaults to current working directory when omitted
 
 Options:
-  --version, -v   Show version number
-  --help, -h      Show this help message
+  --version, -v             Show version number
+  --help, -h                Show this help message
+  --allowed-extensions=...  Comma-separated extra file extensions to permit on
+                            read/write (e.g. ".html,.csv,.json"). Additive to the
+                            built-in defaults (.md, .markdown, .txt, .base, .canvas).
+                            Leading dot optional.
 
 Examples:
   npx @bitbonsai/mcpvault
   npx @bitbonsai/mcpvault ~/Documents/MyVault
-  npx @bitbonsai/mcpvault ./Vault
-  npx @bitbonsai/mcpvault /path/to/obsidian/vault
+  npx @bitbonsai/mcpvault ./Vault --allowed-extensions=.html,.csv
   npx @bitbonsai/mcpvault "/path/with spaces/Obsidian Vault"
 `);
   process.exit(0);
 }
 
+// Parse recognized flags, then treat the remaining positional args as the vault path.
+const allowedExtensions = parseAllowedExtensions(cliArgs);
+const positionalArgs = stripKnownFlags(cliArgs);
+
 // Join trailing args to support vault paths with spaces.
 // When omitted, default to current working directory.
-const vaultPathArg = cliArgs.join(' ').trim();
+const vaultPathArg = positionalArgs.join(' ').trim();
 const vaultPath = resolve(vaultPathArg || process.cwd());
 
-const server = createServer(vaultPath, { version: VERSION });
+// A PathFilter carrying the extra extensions; PathFilter merges them additively
+// onto its built-in allowlist, so createServer needs no change for this flag.
+const pathFilter = allowedExtensions
+  ? new PathFilter({ allowedExtensions })
+  : undefined;
+
+const server = createServer(vaultPath, {
+  version: VERSION,
+  ...(pathFilter && { pathFilter }),
+});
 const transport = new StdioServerTransport();
 await server.connect(transport);
 

--- a/src/append-only.test.ts
+++ b/src/append-only.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { FileSystemService } from "./filesystem.js";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("append-only overwrite protection", () => {
+  let vault: string;
+
+  beforeEach(async () => {
+    vault = await mkdtemp(join(tmpdir(), "mcpvault-append-only-"));
+  });
+
+  afterEach(async () => {
+    await rm(vault, { recursive: true, force: true });
+  });
+
+  test("refuses overwrite of a configured append-only file", async () => {
+    const fs = new FileSystemService(vault, undefined, undefined, ["log.md"]);
+    await fs.writeNote({ path: "log.md", content: "entry 1\n", mode: "append" });
+    await expect(
+      fs.writeNote({ path: "log.md", content: "wiped\n", mode: "overwrite" })
+    ).rejects.toThrow(/append-only/i);
+  });
+
+  test("still allows append and prepend on a configured file", async () => {
+    const fs = new FileSystemService(vault, undefined, undefined, ["log.md"]);
+    await fs.writeNote({ path: "log.md", content: "a\n", mode: "append" });
+    await fs.writeNote({ path: "log.md", content: "b\n", mode: "prepend" });
+    const note = await fs.readNote("log.md");
+    expect(note.content).toContain("a\n");
+    expect(note.content).toContain("b\n");
+  });
+
+  test("does not affect files that are not configured", async () => {
+    const fs = new FileSystemService(vault, undefined, undefined, ["log.md"]);
+    await fs.writeNote({ path: "notes.md", content: "v1", mode: "overwrite" });
+    await fs.writeNote({ path: "notes.md", content: "v2", mode: "overwrite" });
+    expect((await fs.readNote("notes.md")).content).toBe("v2");
+  });
+
+  test("no protection by default (backward compatible)", async () => {
+    const fs = new FileSystemService(vault);
+    await fs.writeNote({ path: "log.md", content: "v1", mode: "overwrite" });
+    await fs.writeNote({ path: "log.md", content: "v2", mode: "overwrite" });
+    expect((await fs.readNote("log.md")).content).toBe("v2");
+  });
+});

--- a/src/atomic-write.test.ts
+++ b/src/atomic-write.test.ts
@@ -1,0 +1,42 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import { FileSystemService } from "./filesystem.js";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+describe("atomic + serialized note writes", () => {
+  let vault: string;
+  let fs: FileSystemService;
+
+  beforeEach(async () => {
+    vault = await mkdtemp(join(tmpdir(), "mcpvault-atomic-"));
+    fs = new FileSystemService(vault);
+  });
+
+  afterEach(async () => {
+    await rm(vault, { recursive: true, force: true });
+  });
+
+  test("concurrent appends to the same note do not clobber each other", async () => {
+    await fs.writeNote({ path: "log.md", content: "start\n", mode: "overwrite" });
+
+    const count = 25;
+    await Promise.all(
+      Array.from({ length: count }, (_, i) =>
+        fs.writeNote({ path: "log.md", content: `line-${i}\n`, mode: "append" })
+      )
+    );
+
+    const note = await fs.readNote("log.md");
+    for (let i = 0; i < count; i++) {
+      expect(note.content).toContain(`line-${i}\n`);
+    }
+  });
+
+  test("no temp files are left behind after a successful write", async () => {
+    await fs.writeNote({ path: "note.md", content: "hello", mode: "overwrite" });
+    const entries = await readdir(vault);
+    expect(entries).toContain("note.md");
+    expect(entries.filter((e) => e.includes(".tmp-"))).toEqual([]);
+  });
+});

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "vitest";
-import { parseAllowedExtensions, stripKnownFlags } from "./cli.js";
+import { parseAllowedExtensions, parseAppendOnly, stripKnownFlags } from "./cli.js";
 
 describe("parseAllowedExtensions", () => {
   test("returns undefined when the flag is absent", () => {
@@ -24,10 +24,27 @@ describe("parseAllowedExtensions", () => {
   });
 });
 
+describe("parseAppendOnly", () => {
+  test("returns undefined when the flag is absent", () => {
+    expect(parseAppendOnly(["/vault"])).toBeUndefined();
+  });
+
+  test("splits, trims, and drops empty entries", () => {
+    expect(parseAppendOnly(["--append-only=log.md, journal.md ,,"])).toEqual([
+      "log.md",
+      "journal.md",
+    ]);
+  });
+});
+
 describe("stripKnownFlags", () => {
-  test("removes the flag and keeps the positional vault path", () => {
-    expect(stripKnownFlags(["/my vault", "--allowed-extensions=.html"])).toEqual(
-      ["/my vault"]
-    );
+  test("removes known flags and keeps the positional vault path", () => {
+    expect(
+      stripKnownFlags([
+        "/my vault",
+        "--allowed-extensions=.html",
+        "--append-only=log.md",
+      ])
+    ).toEqual(["/my vault"]);
   });
 });

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "vitest";
+import { parseAllowedExtensions, stripKnownFlags } from "./cli.js";
+
+describe("parseAllowedExtensions", () => {
+  test("returns undefined when the flag is absent", () => {
+    expect(parseAllowedExtensions(["/vault"])).toBeUndefined();
+  });
+
+  test("adds a leading dot when missing", () => {
+    expect(parseAllowedExtensions(["--allowed-extensions=html,csv"])).toEqual([
+      ".html",
+      ".csv",
+    ]);
+  });
+
+  test("preserves existing dots, trims, and drops empty entries", () => {
+    expect(
+      parseAllowedExtensions(["--allowed-extensions=.html, .csv ,,"])
+    ).toEqual([".html", ".csv"]);
+  });
+
+  test("an empty value yields an empty list, not undefined", () => {
+    expect(parseAllowedExtensions(["--allowed-extensions="])).toEqual([]);
+  });
+});
+
+describe("stripKnownFlags", () => {
+  test("removes the flag and keeps the positional vault path", () => {
+    expect(stripKnownFlags(["/my vault", "--allowed-extensions=.html"])).toEqual(
+      ["/my vault"]
+    );
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure CLI argument parsers, kept separate from server.ts so they can be
+ * unit-tested without importing server.ts (which starts the server on import).
+ */
+
+const ALLOWED_EXTENSIONS_FLAG = "--allowed-extensions=";
+
+/** Read a `--name=a,b,c` flag into a trimmed, non-empty list, or undefined if absent. */
+function readCsvFlag(args: string[], prefix: string): string[] | undefined {
+  const raw = args.find((a) => a.startsWith(prefix));
+  if (raw === undefined) return undefined;
+  return raw
+    .slice(prefix.length)
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+}
+
+/**
+ * Parse `--allowed-extensions=.html,csv` into ['.html', '.csv'] (a leading dot is
+ * added when missing). Returns undefined when the flag is absent, so the caller
+ * can leave PathFilter at its built-in defaults.
+ */
+export function parseAllowedExtensions(args: string[]): string[] | undefined {
+  const values = readCsvFlag(args, ALLOWED_EXTENSIONS_FLAG);
+  return values?.map((e) => (e.startsWith(".") ? e : `.${e}`));
+}
+
+/** Drop recognized `--flag=...` options, leaving positional args (e.g. the vault path). */
+export function stripKnownFlags(args: string[]): string[] {
+  return args.filter((a) => !a.startsWith(ALLOWED_EXTENSIONS_FLAG));
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@
  */
 
 const ALLOWED_EXTENSIONS_FLAG = "--allowed-extensions=";
+const APPEND_ONLY_FLAG = "--append-only=";
 
 /** Read a `--name=a,b,c` flag into a trimmed, non-empty list, or undefined if absent. */
 function readCsvFlag(args: string[], prefix: string): string[] | undefined {
@@ -26,7 +27,18 @@ export function parseAllowedExtensions(args: string[]): string[] | undefined {
   return values?.map((e) => (e.startsWith(".") ? e : `.${e}`));
 }
 
+/**
+ * Parse `--append-only=log.md,journal.md` into ['log.md', 'journal.md']: basenames
+ * whose whole-file overwrite is refused (clients must append/prepend). Returns
+ * undefined when the flag is absent.
+ */
+export function parseAppendOnly(args: string[]): string[] | undefined {
+  return readCsvFlag(args, APPEND_ONLY_FLAG);
+}
+
 /** Drop recognized `--flag=...` options, leaving positional args (e.g. the vault path). */
 export function stripKnownFlags(args: string[]): string[] {
-  return args.filter((a) => !a.startsWith(ALLOWED_EXTENSIONS_FLAG));
+  return args.filter(
+    (a) => !a.startsWith(ALLOWED_EXTENSIONS_FLAG) && !a.startsWith(APPEND_ONLY_FLAG),
+  );
 }

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -15,6 +15,8 @@ export interface CreateServerOptions {
   version?: string;
   pathFilter?: PathFilter;
   frontmatterHandler?: FrontmatterHandler;
+  /** Basenames refused for whole-file overwrite via write_note; clients must append/prepend. */
+  appendOnly?: string[];
 }
 
 export function createServer(vaultPath: string, options: CreateServerOptions = {}): Server {
@@ -23,10 +25,11 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
     version = "0.0.0",
     pathFilter = new PathFilter(),
     frontmatterHandler = new FrontmatterHandler(),
+    appendOnly,
   } = options;
 
   const resolvedVaultPath = resolve(vaultPath);
-  const fileSystem = new FileSystemService(resolvedVaultPath, pathFilter, frontmatterHandler);
+  const fileSystem = new FileSystemService(resolvedVaultPath, pathFilter, frontmatterHandler, appendOnly);
   const searchService = new SearchService(resolvedVaultPath, pathFilter);
 
   const server = new Server({ name, version }, {

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -39,6 +39,8 @@ export function classifyWriteError(error: unknown, path: string): Error {
 export class FileSystemService {
   private frontmatterHandler: FrontmatterHandler;
   private pathFilter: PathFilter;
+  /** Per-absolute-path write serialization; closes the read-modify-write race within this process. */
+  private writeChains: Map<string, Promise<void>> = new Map();
 
   constructor(
     private vaultPath: string,
@@ -133,6 +135,42 @@ export class FileSystemService {
     return fullPath;
   }
 
+  /**
+   * Serialize async mutations to a single absolute path: concurrent calls for the
+   * same path run one at a time in arrival order, while different paths stay
+   * parallel. Prevents two read-modify-write callers from interleaving and
+   * clobbering each other's changes.
+   */
+  private async withPathLock<T>(fullPath: string, fn: () => Promise<T>): Promise<T> {
+    const prev = this.writeChains.get(fullPath) ?? Promise.resolve();
+    let release!: () => void;
+    const mine = new Promise<void>((res) => { release = res; });
+    const chained = prev.then(() => mine);
+    this.writeChains.set(fullPath, chained);
+    await prev.catch(() => {});
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.writeChains.get(fullPath) === chained) {
+        this.writeChains.delete(fullPath);
+      }
+    }
+  }
+
+  /** Write a file atomically: write a temp sibling, then rename over the target (atomic on the same filesystem). */
+  private async atomicWrite(fullPath: string, content: string): Promise<void> {
+    await mkdir(dirname(fullPath), { recursive: true });
+    const tmpPath = `${fullPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    try {
+      await writeFile(tmpPath, content, 'utf-8');
+      await rename(tmpPath, fullPath);
+    } catch (err) {
+      try { await unlink(tmpPath); } catch { /* best effort */ }
+      throw err;
+    }
+  }
+
   async readNote(path: string): Promise<ParsedNote> {
     path = this.normalizePath(path);
     const fullPath = this.resolvePath(path);
@@ -188,58 +226,60 @@ export class FileSystemService {
       }
     }
 
-    try {
-      let finalContent: string;
+    // Serialize the read-modify-write against concurrent writers of the same file,
+    // and replace the file atomically so a torn/partial file is never observed.
+    return this.withPathLock(fullPath, async () => {
+      try {
+        let finalContent: string;
 
-      if (mode === 'overwrite') {
-        // Original behavior - replace entire content
-        finalContent = frontmatter
-          ? this.frontmatterHandler.stringify(frontmatter, content)
-          : content;
-      } else {
-        // For append/prepend, we need to read existing content
-        let existingNote: ParsedNote;
-        try {
-          existingNote = await this.readNote(path);
-        } catch (error) {
-          // File doesn't exist, treat as overwrite
+        if (mode === 'overwrite') {
+          // Original behavior - replace entire content
           finalContent = frontmatter
             ? this.frontmatterHandler.stringify(frontmatter, content)
             : content;
-        }
+        } else {
+          // For append/prepend, we need to read existing content
+          let existingNote: ParsedNote;
+          try {
+            existingNote = await this.readNote(path);
+          } catch (error) {
+            // File doesn't exist, treat as overwrite
+            finalContent = frontmatter
+              ? this.frontmatterHandler.stringify(frontmatter, content)
+              : content;
+          }
 
-        if (existingNote!) {
-          // Merge frontmatter if provided
-          const mergedFrontmatter = frontmatter
-            ? { ...existingNote.frontmatter, ...frontmatter }
-            : existingNote.frontmatter;
+          if (existingNote!) {
+            // Merge frontmatter if provided
+            const mergedFrontmatter = frontmatter
+              ? { ...existingNote.frontmatter, ...frontmatter }
+              : existingNote.frontmatter;
 
-          const mergedContent = mode === 'append'
-            ? existingNote.content + content
-            : content + existingNote.content;
+            const mergedContent = mode === 'append'
+              ? existingNote.content + content
+              : content + existingNote.content;
 
-          if (existingNote.matter && existingNote.matter.trim() !== '') {
-            // Preserve raw formatting for unmodified fields by only applying explicit updates
-            finalContent = this.frontmatterHandler.preserveStringify(
-              existingNote.matter,
-              frontmatter || {},
-              mergedContent
-            );
-          } else {
-            finalContent = this.frontmatterHandler.stringify(
-              mergedFrontmatter,
-              mergedContent
-            );
+            if (existingNote.matter && existingNote.matter.trim() !== '') {
+              // Preserve raw formatting for unmodified fields by only applying explicit updates
+              finalContent = this.frontmatterHandler.preserveStringify(
+                existingNote.matter,
+                frontmatter || {},
+                mergedContent
+              );
+            } else {
+              finalContent = this.frontmatterHandler.stringify(
+                mergedFrontmatter,
+                mergedContent
+              );
+            }
           }
         }
-      }
 
-      // Create directories if they don't exist
-      await mkdir(dirname(fullPath), { recursive: true });
-      await writeFile(fullPath, finalContent!, 'utf-8');
-    } catch (error) {
-      throw classifyWriteError(error, path);
-    }
+        await this.atomicWrite(fullPath, finalContent!);
+      } catch (error) {
+        throw classifyWriteError(error, path);
+      }
+    });
   }
 
   async patchNote(params: PatchNoteParams): Promise<PatchNoteResult> {
@@ -280,53 +320,56 @@ export class FileSystemService {
       };
     }
 
+    const fullPath = this.resolvePath(path);
+
     try {
-      // Read the existing note
-      const note = await this.readNote(path);
+      // Serialize the read-modify-write and replace the file atomically.
+      return await this.withPathLock(fullPath, async () => {
+        // Read the existing note
+        const note = await this.readNote(path);
 
-      // Get the full content with frontmatter
-      const fullContent = note.originalContent;
+        // Get the full content with frontmatter
+        const fullContent = note.originalContent;
 
-      // Count occurrences of oldString
-      const occurrences = fullContent.split(oldString).length - 1;
+        // Count occurrences of oldString
+        const occurrences = fullContent.split(oldString).length - 1;
 
-      if (occurrences === 0) {
+        if (occurrences === 0) {
+          return {
+            success: false,
+            path,
+            message: `String not found in note: "${oldString.substring(0, 50)}${oldString.length > 50 ? '...' : ''}"`,
+            matchCount: 0
+          };
+        }
+
+        // If not replaceAll and multiple occurrences exist, fail
+        if (!replaceAll && occurrences > 1) {
+          return {
+            success: false,
+            path,
+            message: `Found ${occurrences} occurrences of the string. Use replaceAll=true to replace all occurrences, or provide a more specific string to match exactly one occurrence.`,
+            matchCount: occurrences
+          };
+        }
+
+        // Perform the replacement
+        // Use a replacer function so newString is inserted literally,
+        // without $ replacement pattern expansion ($$, $&, $`, $')
+        const updatedContent = replaceAll
+          ? fullContent.split(oldString).join(newString)
+          : fullContent.replace(oldString, () => newString);
+
+        // Write the updated content atomically
+        await this.atomicWrite(fullPath, updatedContent);
+
         return {
-          success: false,
+          success: true,
           path,
-          message: `String not found in note: "${oldString.substring(0, 50)}${oldString.length > 50 ? '...' : ''}"`,
-          matchCount: 0
-        };
-      }
-
-      // If not replaceAll and multiple occurrences exist, fail
-      if (!replaceAll && occurrences > 1) {
-        return {
-          success: false,
-          path,
-          message: `Found ${occurrences} occurrences of the string. Use replaceAll=true to replace all occurrences, or provide a more specific string to match exactly one occurrence.`,
+          message: `Successfully replaced ${replaceAll ? occurrences : 1} occurrence${occurrences > 1 ? 's' : ''}`,
           matchCount: occurrences
         };
-      }
-
-      // Perform the replacement
-      // Use a replacer function so newString is inserted literally,
-      // without $ replacement pattern expansion ($$, $&, $`, $')
-      const updatedContent = replaceAll
-        ? fullContent.split(oldString).join(newString)
-        : fullContent.replace(oldString, () => newString);
-
-      // Write the updated content
-      const fullPath = this.resolvePath(path);
-      await writeFile(fullPath, updatedContent, 'utf-8');
-
-      return {
-        success: true,
-        path,
-        message: `Successfully replaced ${replaceAll ? occurrences : 1} occurrence${occurrences > 1 ? 's' : ''}`,
-        matchCount: occurrences
-      };
-
+      });
     } catch (error) {
       return {
         success: false,
@@ -828,7 +871,7 @@ export class FileSystemService {
     if (merge && note.matter && note.matter.trim() !== '') {
       // Preserve raw formatting for unmodified fields
       const updatedContent = this.frontmatterHandler.preserveStringify(note.matter, frontmatter, note.content);
-      await writeFile(fullPath, updatedContent, 'utf-8');
+      await this.atomicWrite(fullPath, updatedContent);
     } else {
       // Replace frontmatter entirely (or no existing matter to preserve)
       await this.writeNote({
@@ -965,7 +1008,7 @@ export class FileSystemService {
         );
       }
       const fullPath = this.resolvePath(path);
-      await writeFile(fullPath, updatedContent, 'utf-8');
+      await this.atomicWrite(fullPath, updatedContent);
 
       return {
         path,

--- a/src/filesystem.ts
+++ b/src/filesystem.ts
@@ -1,4 +1,4 @@
-import { join, resolve, relative, dirname } from 'path';
+import { join, resolve, relative, dirname, basename } from 'path';
 import { homedir } from 'os';
 import { readdir, stat, readFile, writeFile, unlink, mkdir, access, rename, copyFile } from 'node:fs/promises';
 import { constants, realpathSync } from 'node:fs';
@@ -41,11 +41,14 @@ export class FileSystemService {
   private pathFilter: PathFilter;
   /** Per-absolute-path write serialization; closes the read-modify-write race within this process. */
   private writeChains: Map<string, Promise<void>> = new Map();
+  /** Basenames refused for whole-file overwrite (opt-in via the --append-only CLI flag). */
+  private readonly appendOnlyBasenames: Set<string>;
 
   constructor(
     private vaultPath: string,
     pathFilter?: PathFilter,
-    frontmatterHandler?: FrontmatterHandler
+    frontmatterHandler?: FrontmatterHandler,
+    appendOnly?: string[]
   ) {
     const resolved = resolve(vaultPath);
     try {
@@ -56,6 +59,7 @@ export class FileSystemService {
     }
     this.pathFilter = pathFilter || new PathFilter();
     this.frontmatterHandler = frontmatterHandler || new FrontmatterHandler();
+    this.appendOnlyBasenames = new Set(appendOnly ?? []);
   }
 
   /**
@@ -211,6 +215,14 @@ export class FileSystemService {
 
     if (!this.pathFilter.isAllowed(path)) {
       throw new Error(`Access denied: ${path}. This path is restricted (system files like .obsidian, .git, and dotfiles are not accessible).`);
+    }
+
+    // Refuse whole-file overwrite of a configured append-only file: a stale client
+    // read followed by mode:'overwrite' would clobber entries another client appended
+    // after that read. mode:'append'/'prepend' re-read the file server-side under the
+    // per-path lock at write time, so they cannot lose concurrent data.
+    if (mode === 'overwrite' && this.appendOnlyBasenames.has(basename(path))) {
+      throw new Error(`Refused overwrite of append-only file '${basename(path)}'. Whole-file overwrite can clobber concurrent changes from other clients; use mode:'append' or mode:'prepend' instead.`);
     }
 
     // Validate content is a defined string to prevent writing literal "undefined"


### PR DESCRIPTION
Three independent changes, one per commit, so each can be taken or dropped on its own.

### 1. `feat: add --allowed-extensions CLI flag`
Exposes `PathFilter`s existing `allowedExtensions` config through the CLI, so users can permit non-default file types (`.html`, `.csv`, `.json`, ...) on read/write without recompiling. Additive to the built-in defaults; `createServer` is unchanged (server.ts injects a preconfigured `PathFilter`). Arg parsing is extracted into a unit-tested `src/cli.ts`.

### 2. `fix: make note writes atomic and serialized`
Complements #98 (which fixed the `r+` length bug). `writeFile` still truncates-then-writes, so two gaps remain:
- **Not crash-safe:** a crash or a stalled network-backed mount (rclone/cloud) mid-write leaves a truncated/partial note.
- **Not concurrency-safe:** two overlapping `write_note`/`patch_note` calls to the same path interleave and lose each others changes.

Adds `atomicWrite` (write a temp sibling, then `rename` over the target) and `withPathLock` (per-path serialization). All in-place note writes go through `atomicWrite`; `write_note`/`patch_note` additionally run their read-modify-write under the lock.

### 3. `feat: add --append-only flag to protect files from overwrite`
Opt-in `--append-only=<name,...>`: for the listed basenames, `write_note` `mode:overwrite` is refused (clients must `append`/`prepend`). `write_note` defaults to overwrite, so an AI client that forgets the mode can wipe an append-heavy file (e.g. an operations log) with a stale-read overwrite. Off by default, so existing behavior is unchanged.

### Tests
Adds `src/cli.test.ts`, `src/atomic-write.test.ts`, `src/append-only.test.ts` (13 tests). Full suite passes locally on Node 20 **except** `src/shutdown.test.ts > "exits on SIGTERM"`, which is timing-sensitive and unrelated to these changes: its 500ms boot wait races handler registration on a slow host (verified a 2s boot exits code 0).

`dist/` is intentionally not rebuilt in these commits — happy to rebuild it into the PR if you prefer.
