### PR TITLE
fix(frontmatter): preserve CRLF and stop leaking \r into YAML values

### DIFF
--- a/src/frontmatter.test.ts
+++ b/src/frontmatter.test.ts
@@ -215,3 +215,64 @@ describe("parseFrontmatter", () => {
     expect(() => parseFrontmatter(42)).toThrow("frontmatter must be a JSON object");
   });
 });
+
+// ── CRLF (Windows line endings) ──────────────────────────────────────────────
+// Regression: on a CRLF note the raw matter carries a trailing \r into the YAML
+// scalar, so `updateFrontmatter` rewrote tag "a" as "a\r" — a DIFFERENT tag in
+// Obsidian — and silently replaced the whole frontmatter block with LF while the
+// body stayed CRLF. All three write paths (update_frontmatter, manage_tags and
+// write_note append/prepend) funnel through preserveStringify, so they shared it.
+
+const crlfNote = [
+  "---",
+  "title: Test",
+  "tags:",
+  "  - a",
+  "---",
+  "",
+  "# Head",
+  "body line",
+  "",
+].join("\r\n");
+
+describe("CRLF notes", () => {
+  test("parse does not leak \r into frontmatter values", () => {
+    const parsed = handler.parse(crlfNote);
+
+    expect(parsed.frontmatter.title).toBe("Test");
+    expect(parsed.frontmatter.tags).toEqual(["a"]);
+  });
+
+  test("updateFrontmatter keeps tags intact and does not quote them", () => {
+    const out = handler.updateFrontmatter(crlfNote, { status: "ok" });
+
+    expect(out).not.toContain('"a\r"');
+    expect(out).not.toContain("a\r\r");
+    expect(handler.parse(out).frontmatter.tags).toEqual(["a"]);
+    expect(handler.parse(out).frontmatter.status).toBe("ok");
+  });
+
+  test("updateFrontmatter preserves CRLF throughout the file", () => {
+    const out = handler.updateFrontmatter(crlfNote, { status: "ok" });
+
+    // every \n must be part of a \r\n pair — no mixed endings
+    expect(out.replace(/\r\n/g, "")).not.toContain("\n");
+    expect(out.startsWith("---\r\n")).toBe(true);
+  });
+
+  test("appending to a CRLF note does not corrupt frontmatter", () => {
+    const parsed = handler.parse(crlfNote);
+    const out = handler.preserveStringify(parsed.matter, {}, parsed.content + "appended\r\n");
+
+    expect(handler.parse(out).frontmatter.tags).toEqual(["a"]);
+    expect(out).toContain("appended");
+  });
+
+  test("LF notes stay LF (no regression)", () => {
+    const lfNote = crlfNote.replace(/\r\n/g, "\n");
+    const out = handler.updateFrontmatter(lfNote, { status: "ok" });
+
+    expect(out).not.toContain("\r");
+    expect(handler.parse(out).frontmatter.tags).toEqual(["a"]);
+  });
+});

--- a/src/frontmatter.ts
+++ b/src/frontmatter.ts
@@ -18,6 +18,26 @@ function withYamlEngine(options: Record<string, any> = {}): Record<string, any> 
   return { ...options, engines: { yaml: yamlEngine } };
 }
 
+/** The dominant line ending of a chunk of text. Defaults to LF when there is none. */
+function detectEol(text: string): '\r\n' | '\n' {
+  return text.includes('\r\n') ? '\r\n' : '\n';
+}
+
+/**
+ * Normalize line endings to LF for YAML parsing. Also drops stray CRs: gray-matter
+ * hands back the raw matter of a CRLF note with a trailing \r (the one before the
+ * closing ---), which YAML would otherwise fold into the last scalar — turning the
+ * tag `a` into `a\r`, a different tag as far as Obsidian is concerned.
+ */
+function toLf(text: string): string {
+  return text.replace(/\r\n/g, '\n').replace(/\r/g, '');
+}
+
+/** Re-apply CRLF to LF-only text. */
+function applyEol(text: string, eol: '\r\n' | '\n'): string {
+  return eol === '\r\n' ? text.replace(/\n/g, '\r\n') : text;
+}
+
 /**
  * Parse a frontmatter value that may be a JSON string (LLM clients sometimes
  * pass frontmatter as a serialized JSON string instead of an object).
@@ -48,8 +68,15 @@ export class FrontmatterHandler {
   parse(content: string): ParsedNote {
     try {
       const parsed = matter(content, withYamlEngine());
+      // On a CRLF note the raw matter carries stray CRs that YAML folds into the
+      // last scalar, so re-parse the frontmatter from an LF-normalized copy.
+      // content/originalContent stay byte-identical — patch_note matches on them.
+      let data = parsed.data;
+      if (parsed.matter && parsed.matter.includes('\r')) {
+        data = (parse(toLf(parsed.matter)) as Record<string, any>) ?? {};
+      }
       return {
-        frontmatter: parsed.data,
+        frontmatter: data,
         content: parsed.content,
         originalContent: content,
         matter: parsed.matter
@@ -160,7 +187,11 @@ export class FrontmatterHandler {
         return matter.stringify(content, updates, withYamlEngine());
       }
 
-      const doc = parseDocument(rawMatter.trimStart());
+      // Keep the note's own line endings: the YAML round-trip is done in LF and
+      // re-encoded afterwards, so a CRLF note does not come back with an LF
+      // frontmatter block glued onto a CRLF body.
+      const eol = rawMatter.includes('\r\n') ? '\r\n' : detectEol(content);
+      const doc = parseDocument(toLf(rawMatter).trimStart());
       for (const [key, value] of Object.entries(updates)) {
         if (value === undefined) {
           doc.delete(key);
@@ -168,8 +199,8 @@ export class FrontmatterHandler {
           doc.set(key, value);
         }
       }
-      const yamlContent = doc.toString();
-      return `---\n${yamlContent}---\n${content}`;
+      const yamlContent = applyEol(doc.toString(), eol);
+      return `---${eol}${yamlContent}---${eol}${content}`;
     } catch (error) {
       throw new Error(`Failed to stringify frontmatter: ${error instanceof Error ? error.message : 'Unknown error'}`);
     }


### PR DESCRIPTION
On a note that uses CRLF line endings, editing frontmatter silently renames tags.

## Reproduction

A note saved with CRLF (the default on Windows, and common in vaults synced from Windows machines):

```
---\r\n
title: Test\r\n
tags:\r\n
  - a\r\n
---\r\n
\r\n
# Head\r\n
```

Calling `update_frontmatter` (or `manage_tags`, or `write_note` with `mode: append`) writes back:

```yaml
---
title: Test
tags:
  - "a\r"
status: ok
---
```

The tag `a` has become `a\r`. Obsidian treats that as a **different tag**, so the original silently disappears from the tag graph. No error is returned. The frontmatter block is also rewritten with LF while the body keeps its CRLF, leaving the file with mixed line endings.

## Cause

`gray-matter` returns the raw matter of a CRLF note with a trailing `\r` — the one just before the closing `---`. YAML folds that into the last scalar, which is why it ends up inside the tag value and gets quoted on the way out.

Separately, `preserveStringify` hard-codes the delimiters:

```js
return `---\n${yamlContent}---\n${content}`;
```

so even a correctly parsed CRLF note comes back with an LF frontmatter block glued onto a CRLF body.

Every write path that goes through `preserveStringify` is affected: `update_frontmatter`, `manage_tags`, and `write_note` in `append`/`prepend` mode.

## Fix

- Run the YAML round-trip on an LF-normalized copy, then re-apply the note original line ending when writing back.
- `parse()` re-reads the frontmatter from a normalized copy when the raw matter contains `\r`, so values come back clean.
- `content` and `originalContent` are left byte-identical, so `patch_note` keeps matching exactly as before — this change does not alter what a patch sees.
- LF notes are unaffected (covered by a no-op test).

## Tests

Five regression tests in `src/frontmatter.test.ts`: parsing, updating, appending, CRLF preservation across the whole file, and the LF no-regression case. Without the fix, four of them fail with `expected [ "a\r" ] to deeply equal [ "a" ]`.

`npm run build` is clean. Note that a few suites (`shutdown.test.ts` and friends) already fail on my machine before this change — same count on a clean checkout of `main`, so unrelated.

## Related

I also have a small follow-up PR adding MCP tool annotations, kept separate on purpose.