### PR TITLE
feat(tools): declare MCP annotations for every tool

### DIFF
--- a/src/createServer.test.ts
+++ b/src/createServer.test.ts
@@ -224,3 +224,39 @@ test("wiki_link resolves path-qualified link to the exact file", async () => {
     await server.close();
   }
 });
+
+// ── Tool annotations ─────────────────────────────────────────────────────────
+// Without annotations a client cannot tell delete_note apart from read_note:
+// MCP proxies derive the call variant from these hints, and an unannotated tool
+// falls back to whatever default that proxy picked.
+
+test("every tool carries annotations and stays closed-world", async () => {
+  const server = createServer(process.cwd());
+  // @ts-expect-error — reaching into the registered ListTools handler
+  const { tools } = await server._requestHandlers.get("tools/list")({ method: "tools/list", params: {} }, {});
+
+  expect(tools.length).toBeGreaterThan(0);
+  for (const tool of tools) {
+    expect(tool.annotations, `${tool.name} has no annotations`).toBeDefined();
+    expect(tool.annotations.openWorldHint, `${tool.name} should be closed-world`).toBe(false);
+  }
+});
+
+test("destructive and read-only tools are marked as such", async () => {
+  const server = createServer(process.cwd());
+  // @ts-expect-error — reaching into the registered ListTools handler
+  const { tools } = await server._requestHandlers.get("tools/list")({ method: "tools/list", params: {} }, {});
+  const byName = Object.fromEntries(tools.map((t: any) => [t.name, t.annotations]));
+
+  expect(byName.delete_note.destructiveHint).toBe(true);
+  expect(byName.delete_note.readOnlyHint).toBe(false);
+
+  expect(byName.read_note.readOnlyHint).toBe(true);
+  expect(byName.search_notes.readOnlyHint).toBe(true);
+  expect(byName.wiki_link.readOnlyHint).toBe(true);
+
+  // mutating, but must not be reported as destructive
+  expect(byName.write_note.readOnlyHint).toBe(false);
+  expect(byName.write_note.destructiveHint).toBe(false);
+  expect(byName.patch_note.destructiveHint).toBe(false);
+});

--- a/src/createServer.ts
+++ b/src/createServer.ts
@@ -10,6 +10,47 @@ import { SearchService } from "./search.js";
 import { handleWikiLinkTool } from "./wikilink/index.js";
 import { resolve } from "path";
 
+/**
+ * Per-tool behaviour hints (MCP tool annotations).
+ *
+ * Clients and proxies route calls by these: with no annotations at all, a strict
+ * client has to assume the worst for every tool, while a permissive one shows
+ * `delete_note` as indistinguishable from `read_note`. Everything here is local
+ * to the vault, so `openWorldHint` is false across the board (applied below).
+ */
+const TOOL_ANNOTATIONS: Record<
+  string,
+  { readOnlyHint?: boolean; destructiveHint?: boolean; idempotentHint?: boolean }
+> = {
+  // Read-only
+  read_note: { readOnlyHint: true },
+  list_directory: { readOnlyHint: true },
+  search_notes: { readOnlyHint: true },
+  read_multiple_notes: { readOnlyHint: true },
+  get_notes_info: { readOnlyHint: true },
+  get_frontmatter: { readOnlyHint: true },
+  get_vault_stats: { readOnlyHint: true },
+  list_all_tags: { readOnlyHint: true },
+  wiki_link: { readOnlyHint: true },
+  // Mutating but not destructive: they add or amend, they do not drop content
+  write_note: { readOnlyHint: false, destructiveHint: false },
+  patch_note: { readOnlyHint: false, destructiveHint: false },
+  update_frontmatter: { readOnlyHint: false, destructiveHint: false, idempotentHint: true },
+  manage_tags: { readOnlyHint: false, destructiveHint: false },
+  // Destructive: remove or overwrite something that existed
+  delete_note: { readOnlyHint: false, destructiveHint: true },
+  move_note: { readOnlyHint: false, destructiveHint: true },
+  move_file: { readOnlyHint: false, destructiveHint: true },
+};
+
+/** Attach the annotations above to a tool list, defaulting every tool to closed-world. */
+function withAnnotations<T extends { name: string }>(tools: T[]): T[] {
+  return tools.map((tool) => ({
+    ...tool,
+    annotations: { openWorldHint: false, ...TOOL_ANNOTATIONS[tool.name] },
+  }));
+}
+
 export interface CreateServerOptions {
   name?: string;
   version?: string;
@@ -35,7 +76,7 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     return {
-      tools: [
+      tools: withAnnotations([
         {
           name: "read_note",
           description: "Read a note from the Obsidian vault",
@@ -250,7 +291,7 @@ export function createServer(vaultPath: string, options: CreateServerOptions = {
             required: ["document"]
           }
         }
-      ]
+      ])
     };
   });
 


### PR DESCRIPTION
None of the 16 tools currently declare [tool annotations](https://modelcontextprotocol.io/specification/2025-06-18/server/tools#tool-annotations), so a client has no way to tell `delete_note` apart from `read_note`.

## Why it matters in practice

MCP proxies and clients route calls by these hints. I run mcpvault behind [mcpproxy-go](https://github.com/smart-mcp-proxy/mcpproxy-go), which exposes three call variants (`call_tool_read` / `call_tool_write` / `call_tool_destructive`) and picks one per tool from its annotations. With none present it falls back to its safe default and recommends **`call_tool_read` for `delete_note`, `move_note` and `write_note` alike** — the destructive tools look exactly as harmless as the read-only ones to the agent.

The same hints drive discovery filters (`readOnlyOnly`, `excludeDestructive`), so unannotated tools also get filtered inconsistently: a strict client has to assume the worst for all 16, a permissive one assumes the best.

## What this adds

Per-tool `readOnlyHint` / `destructiveHint`, plus `openWorldHint: false` on every tool since all of them operate on the local vault and never reach the network:

| Category | Tools |
|---|---|
| Read-only | `read_note`, `list_directory`, `search_notes`, `read_multiple_notes`, `get_notes_info`, `get_frontmatter`, `get_vault_stats`, `list_all_tags`, `wiki_link` |
| Mutating, non-destructive | `write_note`, `patch_note`, `update_frontmatter`, `manage_tags` |
| Destructive | `delete_note`, `move_note`, `move_file` |

`update_frontmatter` is additionally marked `idempotentHint: true`.

Two judgement calls worth flagging, happy to change either:

- **`move_note` / `move_file` as destructive** — they can overwrite an existing file when `overwrite: true`, and a rename is not reversible from the client side. If you would rather treat them as plain writes, it is a one-line change.
- **`patch_note` as non-destructive** — it replaces a string the caller supplied and fails on ambiguous matches, so it felt closer to an edit than a destructive op.

## Implementation

Annotations live in a small `TOOL_ANNOTATIONS` map applied via `withAnnotations()` when the tool list is returned, rather than being inlined into all 16 literals — keeps the diff small and the defaults in one place.

Two tests in `src/createServer.test.ts`: every tool carries annotations and is closed-world, and the destructive/read-only ones are marked correctly. `npm run build` is clean.

## Related

Sent alongside a separate PR fixing CRLF handling in frontmatter — independent of this one.