### PR TITLE
docs: clarify wiki link resolution order

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,4 +136,4 @@ When modifying file operations:
 - TypeScript toolchain upgrades change dist output (TS7 altered `.d.ts.map` sourcemaps only) — rebuild + commit dist after any TS bump or the dirty tree blocks automation that requires clean main.
 - Claude Code discovers skills only under `.claude/skills/`; repo keeps them in `skills/`. Committed symlink `.claude/skills/triage -> ../../skills/triage` bridges it — same pattern for any new skill.
 - `pathFilter.isAllowed` + `normalizePath` must guard EVERY new tool's path input (PR #146 blocker: `readNoteLines` skipped them = read `.obsidian/` files). Mirror `readNote`'s guard block.
-- Outline/heading parsing must be fence-aware: `#` lines inside ``` blocks are not headings (`patch_note` has prior art).
+- Outline/heading parsing must be fence-aware: headings inside code fences do not count. Support backtick and tilde fences with up to three leading spaces, and require closing fences to use the same marker with at least the opening length.

--- a/README.md
+++ b/README.md
@@ -126,13 +126,14 @@ MCP is an open protocol. You're not tied to any specific vendor or platform. You
 
 - ✅ Safe frontmatter parsing and validation using gray-matter with AST-aware updates that preserve raw formatting for unmodified fields
 - ✅ Path filtering to exclude `.obsidian` directory and other system files
-- ✅ **Complete MCP toolkit**: 14 methods covering all vault operations
+- ✅ **Complete MCP toolkit**: 16 tools covering all vault operations
   - File operations: `read_note`, `write_note`, `patch_note`, `delete_note`, `move_note`, `move_file`
   - Directory operations: `list_directory`
   - Batch operations: `read_multiple_notes`
   - Search: `search_notes` with multi-word matching and BM25 relevance reranking
   - Metadata: `get_frontmatter`, `update_frontmatter`, `get_notes_info`, `get_vault_stats`
-  - Tag management: `manage_tags` (add, remove, list)
+  - Tag management: `manage_tags` (add, remove, list), `list_all_tags`
+  - Wiki links: `wiki_link` picks the shallowest match first (vault root before nested folders), then uses locale-aware path sorting at the same depth. Other matches are returned as alternatives; punctuation may sort before digits, so `_Inbox` can come before `00.projects`.
 - ✅ Write modes: `overwrite`, `append`, `prepend` for flexible content editing
 - ✅ Tag management: add, remove, and list tags in notes
 - ✅ Safe deletion with confirmation requirement to prevent accidents

--- a/website/public/skill.md
+++ b/website/public/skill.md
@@ -24,7 +24,7 @@ Each operation maps to exactly one backend. The skill picks the right one automa
 | Read note | yes | — | — | Safe, sandboxed read via MCP |
 | Write / patch note | yes | — | — | Atomic writes with validation |
 | Search vault | yes | — | — | BM25-ranked full-text search |
-| Resolve [[wiki links]] | yes | — | — | wiki_link follows [[Note]] references and returns the note |
+| Resolve [[wiki links]] | yes | — | — | wiki_link picks the shallowest match first, then locale-sorts equal-depth paths; other matches are returned as alternatives |
 | Manage tags / frontmatter | yes | — | — | Safe YAML merge |
 | List all tags with counts | yes | — | — | Filesystem scan, works headless |
 | Move / rename files | yes | yes | — | CLI move rewrites internal links (app running); MCP move works headless |

--- a/website/src/components/SkillsContent.astro
+++ b/website/src/components/SkillsContent.astro
@@ -27,7 +27,7 @@ const routes = [
     mcp: true,
     app: false,
     git: false,
-    notes: 'wiki_link follows [[Note]] references and returns the note',
+    notes: 'wiki_link picks the shallowest match first, then locale-sorts equal-depth paths; other matches are returned as alternatives',
   },
   {
     operation: 'Manage tags / frontmatter',


### PR DESCRIPTION
## Summary

- document that `wiki_link` chooses shallower paths before nested ones
- clarify that equal-depth matches use locale-aware path ordering, where punctuation may sort before digits
- state that remaining matches are returned as alternatives
- correct the README tool count and include `list_all_tags` and `wiki_link`
- keep the website HTML and Markdown skill content in sync
- correct the fence-parsing guidance in `AGENTS.md` (there is no `patch_note` prior art)

Follow-up to #165.

No package version bump or npm publish is needed because this is documentation-only.

## Verification

- `cd website && npm run build`
