### PR TITLE
feat: add --allowed-extensions CLI flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,12 @@ npm start /path/to/your/obsidian/vault
 npm start ./Vault
 ```
 
+### CLI Options
+
+| Flag | Description |
+| --- | --- |
+| `--allowed-extensions=<ext,...>` | Comma-separated extra file extensions to permit on read/write, additive to the built-in defaults (`.md`, `.markdown`, `.txt`, `.base`, `.canvas`). Leading dot optional. Example: `--allowed-extensions=.html,.csv,.json`. |
+
 ### AI Client Configuration
 
 #### Claude Desktop

--- a/dist/server.js
+++ b/dist/server.js
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./src/createServer.js";
+import { PathFilter } from "./src/pathfilter.js";
+import { parseAllowedExtensions, stripKnownFlags } from "./src/cli.js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join, resolve } from "path";
@@ -23,30 +25,44 @@ mcpvault v${VERSION}
 Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant
 
 Usage:
-  npx @bitbonsai/mcpvault [vault-path]
+  npx @bitbonsai/mcpvault [vault-path] [--allowed-extensions=ext1,ext2,...]
 
 Arguments:
   [vault-path]    Optional path to your Obsidian vault directory
                   Defaults to current working directory when omitted
 
 Options:
-  --version, -v   Show version number
-  --help, -h      Show this help message
+  --version, -v             Show version number
+  --help, -h                Show this help message
+  --allowed-extensions=...  Comma-separated extra file extensions to permit on
+                            read/write (e.g. ".html,.csv,.json"). Additive to the
+                            built-in defaults (.md, .markdown, .txt, .base, .canvas).
+                            Leading dot optional.
 
 Examples:
   npx @bitbonsai/mcpvault
   npx @bitbonsai/mcpvault ~/Documents/MyVault
-  npx @bitbonsai/mcpvault ./Vault
-  npx @bitbonsai/mcpvault /path/to/obsidian/vault
+  npx @bitbonsai/mcpvault ./Vault --allowed-extensions=.html,.csv
   npx @bitbonsai/mcpvault "/path/with spaces/Obsidian Vault"
 `);
     process.exit(0);
 }
+// Parse recognized flags, then treat the remaining positional args as the vault path.
+const allowedExtensions = parseAllowedExtensions(cliArgs);
+const positionalArgs = stripKnownFlags(cliArgs);
 // Join trailing args to support vault paths with spaces.
 // When omitted, default to current working directory.
-const vaultPathArg = cliArgs.join(' ').trim();
+const vaultPathArg = positionalArgs.join(' ').trim();
 const vaultPath = resolve(vaultPathArg || process.cwd());
-const server = createServer(vaultPath, { version: VERSION });
+// A PathFilter carrying the extra extensions; PathFilter merges them additively
+// onto its built-in allowlist, so createServer needs no change for this flag.
+const pathFilter = allowedExtensions
+    ? new PathFilter({ allowedExtensions })
+    : undefined;
+const server = createServer(vaultPath, {
+    version: VERSION,
+    ...(pathFilter && { pathFilter }),
+});
 const transport = new StdioServerTransport();
 await server.connect(transport);
 // Exit when the client disconnects (stdin EOF) or the process is asked to

--- a/dist/src/cli.d.ts
+++ b/dist/src/cli.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Pure CLI argument parsers, kept separate from server.ts so they can be
+ * unit-tested without importing server.ts (which starts the server on import).
+ */
+/**
+ * Parse `--allowed-extensions=.html,csv` into ['.html', '.csv'] (a leading dot is
+ * added when missing). Returns undefined when the flag is absent, so the caller
+ * can leave PathFilter at its built-in defaults.
+ */
+export declare function parseAllowedExtensions(args: string[]): string[] | undefined;
+/** Drop recognized `--flag=...` options, leaving positional args (e.g. the vault path). */
+export declare function stripKnownFlags(args: string[]): string[];
+//# sourceMappingURL=cli.d.ts.map

--- a/dist/src/cli.d.ts.map
+++ b/dist/src/cli.d.ts.map
@@ -1,0 +1,1 @@
+{"version":3,"file":"cli.d.ts","sourceRoot":"","sources":["../../src/cli.ts"],"names":[],"mappings":"AAAA;;;GAGG;AAeH;;;;GAIG;AACH,wBAAgB,sBAAsB,CAAC,IAAI,EAAE,MAAM,EAAE,GAAG,MAAM,EAAE,GAAG,SAAS,CAG3E;AAED,2FAA2F;AAC3F,wBAAgB,eAAe,CAAC,IAAI,EAAE,MAAM,EAAE,GAAG,MAAM,EAAE,CAExD"}

--- a/dist/src/cli.js
+++ b/dist/src/cli.js
@@ -1,0 +1,29 @@
+/**
+ * Pure CLI argument parsers, kept separate from server.ts so they can be
+ * unit-tested without importing server.ts (which starts the server on import).
+ */
+const ALLOWED_EXTENSIONS_FLAG = "--allowed-extensions=";
+/** Read a `--name=a,b,c` flag into a trimmed, non-empty list, or undefined if absent. */
+function readCsvFlag(args, prefix) {
+    const raw = args.find((a) => a.startsWith(prefix));
+    if (raw === undefined)
+        return undefined;
+    return raw
+        .slice(prefix.length)
+        .split(",")
+        .map((v) => v.trim())
+        .filter((v) => v.length > 0);
+}
+/**
+ * Parse `--allowed-extensions=.html,csv` into ['.html', '.csv'] (a leading dot is
+ * added when missing). Returns undefined when the flag is absent, so the caller
+ * can leave PathFilter at its built-in defaults.
+ */
+export function parseAllowedExtensions(args) {
+    const values = readCsvFlag(args, ALLOWED_EXTENSIONS_FLAG);
+    return values?.map((e) => (e.startsWith(".") ? e : `.${e}`));
+}
+/** Drop recognized `--flag=...` options, leaving positional args (e.g. the vault path). */
+export function stripKnownFlags(args) {
+    return args.filter((a) => !a.startsWith(ALLOWED_EXTENSIONS_FLAG));
+}

--- a/server.ts
+++ b/server.ts
@@ -2,6 +2,8 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createServer } from "./src/createServer.js";
+import { PathFilter } from "./src/pathfilter.js";
+import { parseAllowedExtensions, stripKnownFlags } from "./src/cli.js";
 import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join, resolve } from "path";
@@ -30,32 +32,48 @@ mcpvault v${VERSION}
 Universal AI bridge for Obsidian vaults - connect any MCP-compatible assistant
 
 Usage:
-  npx @bitbonsai/mcpvault [vault-path]
+  npx @bitbonsai/mcpvault [vault-path] [--allowed-extensions=ext1,ext2,...]
 
 Arguments:
   [vault-path]    Optional path to your Obsidian vault directory
                   Defaults to current working directory when omitted
 
 Options:
-  --version, -v   Show version number
-  --help, -h      Show this help message
+  --version, -v             Show version number
+  --help, -h                Show this help message
+  --allowed-extensions=...  Comma-separated extra file extensions to permit on
+                            read/write (e.g. ".html,.csv,.json"). Additive to the
+                            built-in defaults (.md, .markdown, .txt, .base, .canvas).
+                            Leading dot optional.
 
 Examples:
   npx @bitbonsai/mcpvault
   npx @bitbonsai/mcpvault ~/Documents/MyVault
-  npx @bitbonsai/mcpvault ./Vault
-  npx @bitbonsai/mcpvault /path/to/obsidian/vault
+  npx @bitbonsai/mcpvault ./Vault --allowed-extensions=.html,.csv
   npx @bitbonsai/mcpvault "/path/with spaces/Obsidian Vault"
 `);
   process.exit(0);
 }
 
+// Parse recognized flags, then treat the remaining positional args as the vault path.
+const allowedExtensions = parseAllowedExtensions(cliArgs);
+const positionalArgs = stripKnownFlags(cliArgs);
+
 // Join trailing args to support vault paths with spaces.
 // When omitted, default to current working directory.
-const vaultPathArg = cliArgs.join(' ').trim();
+const vaultPathArg = positionalArgs.join(' ').trim();
 const vaultPath = resolve(vaultPathArg || process.cwd());
 
-const server = createServer(vaultPath, { version: VERSION });
+// A PathFilter carrying the extra extensions; PathFilter merges them additively
+// onto its built-in allowlist, so createServer needs no change for this flag.
+const pathFilter = allowedExtensions
+  ? new PathFilter({ allowedExtensions })
+  : undefined;
+
+const server = createServer(vaultPath, {
+  version: VERSION,
+  ...(pathFilter && { pathFilter }),
+});
 const transport = new StdioServerTransport();
 await server.connect(transport);
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -1,0 +1,33 @@
+import { describe, test, expect } from "vitest";
+import { parseAllowedExtensions, stripKnownFlags } from "./cli.js";
+
+describe("parseAllowedExtensions", () => {
+  test("returns undefined when the flag is absent", () => {
+    expect(parseAllowedExtensions(["/vault"])).toBeUndefined();
+  });
+
+  test("adds a leading dot when missing", () => {
+    expect(parseAllowedExtensions(["--allowed-extensions=html,csv"])).toEqual([
+      ".html",
+      ".csv",
+    ]);
+  });
+
+  test("preserves existing dots, trims, and drops empty entries", () => {
+    expect(
+      parseAllowedExtensions(["--allowed-extensions=.html, .csv ,,"])
+    ).toEqual([".html", ".csv"]);
+  });
+
+  test("an empty value yields an empty list, not undefined", () => {
+    expect(parseAllowedExtensions(["--allowed-extensions="])).toEqual([]);
+  });
+});
+
+describe("stripKnownFlags", () => {
+  test("removes the flag and keeps the positional vault path", () => {
+    expect(stripKnownFlags(["/my vault", "--allowed-extensions=.html"])).toEqual(
+      ["/my vault"]
+    );
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure CLI argument parsers, kept separate from server.ts so they can be
+ * unit-tested without importing server.ts (which starts the server on import).
+ */
+
+const ALLOWED_EXTENSIONS_FLAG = "--allowed-extensions=";
+
+/** Read a `--name=a,b,c` flag into a trimmed, non-empty list, or undefined if absent. */
+function readCsvFlag(args: string[], prefix: string): string[] | undefined {
+  const raw = args.find((a) => a.startsWith(prefix));
+  if (raw === undefined) return undefined;
+  return raw
+    .slice(prefix.length)
+    .split(",")
+    .map((v) => v.trim())
+    .filter((v) => v.length > 0);
+}
+
+/**
+ * Parse `--allowed-extensions=.html,csv` into ['.html', '.csv'] (a leading dot is
+ * added when missing). Returns undefined when the flag is absent, so the caller
+ * can leave PathFilter at its built-in defaults.
+ */
+export function parseAllowedExtensions(args: string[]): string[] | undefined {
+  const values = readCsvFlag(args, ALLOWED_EXTENSIONS_FLAG);
+  return values?.map((e) => (e.startsWith(".") ? e : `.${e}`));
+}
+
+/** Drop recognized `--flag=...` options, leaving positional args (e.g. the vault path). */
+export function stripKnownFlags(args: string[]): string[] {
+  return args.filter((a) => !a.startsWith(ALLOWED_EXTENSIONS_FLAG));
+}


### PR DESCRIPTION
Split out of #162 as requested — this is the `--allowed-extensions` piece only, rebased on current `main` (9748d7e).

## Why

Vaults hold more than notes: dashboards (`.html`), exports (`.csv`), configs (`.json` / `.yaml`). `PathFilter` already accepts an `allowedExtensions` option, but nothing reaches it from the CLI, so those files stay invisible to the note tools even when the user wants them managed.

## What

- `--allowed-extensions=.html,.csv,.json` — additive to the built-in defaults (`.md`, `.markdown`, `.txt`, `.base`, `.canvas`). Leading dot optional.
- Arg parsing extracted into a new `src/cli.ts` (`parseAllowedExtensions`, `stripKnownFlags`) so it is unit-testable without importing `server.ts`, which starts the server on import.
- `createServer` is untouched — `server.ts` injects a preconfigured `PathFilter` through the existing option.
- Flag absent ⇒ behavior identical to today.

## Tests

`src/cli.test.ts` — 5 cases: flag absent, missing leading dot normalized, trimming and empty entries dropped, empty value yields an empty list, positional vault path preserved.

Full suite on this branch: **249 passed, 1 failed**. The failure is `src/shutdown.test.ts > stdio server exits on SIGTERM`, which **also fails on pristine `main` on this machine** (I checked out `upstream/main` and ran it alone — same failure). It is a boot race: the test allows 500 ms before sending SIGTERM and this box registers the handlers later than that under load. Not introduced by this branch.

End-to-end against the built `dist/server.js`, driven over real MCP stdio:

| `write_note` call | no flag | `--allowed-extensions=html,.csv` |
| --- | --- | --- |
| `page.html` | `Error: Access denied` | `Successfully wrote note: page.html` |
| `note.md` | ok | ok |
| `bin.exe` | `Error: Access denied` | `Error: Access denied` |

(Note the `html` vs `.csv` mix in that invocation — it exercises the optional leading dot.)

## Commits

1. `feat: add --allowed-extensions CLI flag`
2. `chore: rebuild dist` — kept as its own commit, matching 5a293c6.

No `website/` content changed (root `README.md` only), so the HTML/Markdown dual-content rule doesn't come into play here.
