### PR TITLE
fix(skill): route note moves safely

### DIFF
--- a/skills/obsidian/SKILL.md
+++ b/skills/obsidian/SKILL.md
@@ -5,7 +5,7 @@ description: >
   frontmatter, daily notes, backup, or sync. Route operations across MCP,
   Obsidian CLI/app actions, and git sync with safe defaults.
 metadata:
-  version: "2.1"
+  version: "2.2"
   author: bitbonsai
 ---
 
@@ -17,23 +17,33 @@ Use the backend that best matches user intent:
 
 1. **MCP (default for vault data operations)**
    - Read/write/patch/search notes
+   - Move/rename notes with `move_note`, then explicitly repair backlinks
    - Frontmatter and tag updates
    - Metadata and batch note operations
 
 2. **Obsidian CLI/App context (only when app context is needed)**
    - Open a note in Obsidian from URI
    - Trigger app/plugin workflows that MCP cannot perform
-   - **Move/rename notes when the app is running.** The CLI's `move` goes
-     through Obsidian's runtime and rewrites every internal link pointing at
-     the old path. MCP's `move_note` is a filesystem move: backlinks in other
-     notes go stale. If Obsidian is not running, fall back to MCP `move_note`
-     and tell the user backlinks were not updated.
 
 3. **CLI git (sync/backup workflows)**
    - Initialize repo, configure remote, commit, pull, push
    - Periodic or manual vault backup/sync requests
 
 When a request is ambiguous, pick MCP first unless the user explicitly asks for sync/backup/git/app behavior.
+
+## Safe Note Rename Workflow
+
+Use MCP `move_note` for every note move or rename, even when Obsidian is running. Do not invoke the Obsidian CLI `move` command automatically: delayed link rewrites can apply stale byte offsets to notes edited after the move began, silently corrupting unrelated content ([#176](https://github.com/bitbonsai/mcpvault/issues/176)). Reconsider CLI moves only after an upstream fix has been independently retested.
+
+Backlink preservation is an explicit, verifiable second step:
+
+1. Before moving, search for the old wikilink target using both its vault-relative path and filename without the extension. If Obsidian is running, its read-only `backlinks` command may supplement discovery, but it does not replace the MCP search.
+2. Move the note with MCP `move_note`.
+3. Read each referring note and patch only exact wikilink targets, including embeds and links with aliases or fragments. Preserve display text (`|alias`) and `#heading` / `#^block-id` suffixes while changing the target.
+4. Search again for the old path and basename. Report any remaining references instead of claiming success.
+5. `search_notes` returns at most 20 results. If a search reaches that cap, or the old basename is ambiguous, tell the user exhaustive backlink repair cannot be proven and ask before continuing with a broader scan.
+
+Report the move and backlink repair separately: which note moved, how many referring notes changed, and any stale references that remain.
 
 ## Gotchas
 
@@ -143,7 +153,7 @@ When the user asks for app-context operations (active file, open in editor, dail
    - Check Obsidian is running: `pgrep -xiq obsidian` (macOS/Linux) or `tasklist /FI "IMAGENAME eq Obsidian.exe" /NH` (Windows)
    - If either fails, tell the user and fall back to MCP tools + `obsidian://` URIs
 
-2. Vault targeting: `obsidian vault="VaultName" <command>`. The vault name is the folder basename unless `OBSIDIAN_VAULT_NAME` is set.
+2. Vault targeting: `obsidian vault="VaultName" <command>`. If `OBSIDIAN_VAULT_NAME` is set, use that explicit value. Otherwise run `obsidian vaults`, match the MCP vault path to a registered vault, and use its registered name. If no unique match exists, ask the user. Never infer the registered name from the folder basename.
 
 3. Key commands:
    ```bash
@@ -173,19 +183,16 @@ When the user asks for app-context operations (active file, open in editor, dail
 
    # Find unresolved links
    obsidian unresolved
-
-   # Move/rename a note — rewrites all internal links to the old path.
-   # Run `obsidian help move` first for the exact parameters of the
-   # installed version; do not guess them.
-   obsidian move ...
    ```
+
+   Do not use `obsidian move`; follow **Safe Note Rename Workflow** with MCP `move_note` and explicit backlink repair.
 
 4. Run `obsidian help` for the full command reference. The CLI evolves with Obsidian releases.
 
 5. **When to use CLI vs MCP:**
-   - MCP for reads/writes/search/tags/frontmatter (sandboxed, validated, works headless)
-   - CLI for active file, daily notes with template expansion, backlinks, open in editor, plugin commands
-   - CLI for move/rename when the app is running (link-aware; see Routing Policy). MCP `move_note` as fallback, warning that backlinks were not updated
+   - MCP for reads/writes/search/tags/frontmatter and all note moves/renames (sandboxed, validated, works headless)
+   - CLI for active file, daily notes with template expansion, read-only backlink discovery, open in editor, and plugin commands
+   - After `move_note`, repair and verify backlinks explicitly with the Safe Note Rename Workflow
    - If unsure, prefer MCP
 
 ## Resources

--- a/skills/obsidian/resources/tool-patterns.md
+++ b/skills/obsidian/resources/tool-patterns.md
@@ -55,7 +55,7 @@ Auto-creates parent directories recursively. In append/prepend, creates the file
 
 ## move_note
 
-Text-aware move for markdown files. Reads source as UTF-8, writes to destination with `wx` flag (fails if target exists unless `overwrite: true`), then deletes source. No confirmation parameters needed.
+Text-aware move for markdown files. Reads source as UTF-8, writes to destination with `wx` flag (fails if target exists unless `overwrite: true`), then deletes source. No confirmation parameters needed. It does not rewrite wikilinks in other notes; follow the Safe Note Rename Workflow in SKILL.md to discover, repair, and verify backlinks explicitly.
 
 **Response:** `{ "success": bool, "oldPath": str, "newPath": str, "message": str }`
 
@@ -64,8 +64,8 @@ Text-aware move for markdown files. Reads source as UTF-8, writes to destination
 Binary-safe move. Requires double confirmation: `confirmOldPath === oldPath` AND `confirmNewPath === newPath`. Rejects directories. Falls back to copy+unlink for cross-filesystem moves.
 
 **When to use which:**
-- Renaming/moving `.md` files with Obsidian running → Obsidian CLI `move` (rewrites internal links; see SKILL.md Routing Policy)
-- Renaming/moving `.md` files headless → `move_note` (filesystem move; backlinks in other notes go stale — tell the user)
+- Renaming/moving `.md` files, with or without Obsidian running → `move_note`, then explicitly repair and verify backlinks (see SKILL.md Safe Note Rename Workflow)
+- Do not invoke Obsidian CLI `move` automatically; delayed stale-offset rewrites can corrupt notes edited while the command is still running (#176)
 - Moving images, PDFs, attachments → `move_file`
 
 ## read_multiple_notes

--- a/website/public/skill.md
+++ b/website/public/skill.md
@@ -27,7 +27,7 @@ Each operation maps to exactly one backend. The skill picks the right one automa
 | Resolve [[wiki links]] | yes | — | — | wiki_link picks the shallowest match first, then locale-sorts equal-depth paths; other matches are returned as alternatives |
 | Manage tags / frontmatter | yes | — | — | Safe YAML merge |
 | List all tags with counts | yes | — | — | Filesystem scan, works headless |
-| Move / rename files | yes | yes | — | CLI move rewrites internal links (app running); MCP move works headless |
+| Move / rename notes | yes | — | — | MCP move followed by explicit backlink search, repair, and verification |
 | Get active file | — | yes | — | Currently focused file in Obsidian |
 | Open note in Obsidian | — | yes | — | Open by path in editor |
 | Daily notes | — | yes | — | Create/read/append with template expansion |
@@ -44,6 +44,15 @@ The skill routes by intent:
 2. Open-in-editor or app/plugin-context requests route to **Obsidian CLI/App context**.
 3. Sync/backup/store-with-git requests route to **Git CLI**.
 
+### Safe note rename flow
+
+1. Search for the old wikilink target by vault-relative path and filename stem.
+2. Move the note with MCP `move_note`, even when Obsidian is running.
+3. Patch exact wikilink targets in referring notes while preserving aliases, embeds, and heading/block fragments.
+4. Search again and report any stale references. If the 20-result search cap is reached or the basename is ambiguous, do not claim exhaustive repair.
+
+The skill does not invoke `obsidian move` automatically. Delayed link rewrites can use stale byte offsets and corrupt notes edited while the command is still running ([#176](https://github.com/bitbonsai/mcpvault/issues/176)). CLI moves should only be reconsidered after an upstream fix is independently retested.
+
 ### Git sync flow
 
 1. Preflight: verify git, repo, identity, and remote.
@@ -56,7 +65,7 @@ The skill routes by intent:
 ### Routing defaults
 
 - **MCP first** for read/write/search/frontmatter/tags.
-- **Obsidian CLI/App context** for app/editor/plugin-specific behavior, and for move/rename while the app is running — the CLI rewrites internal links that a filesystem move would leave stale (MCP is the headless fallback).
+- **Obsidian CLI/App context** for app/editor/plugin-specific behavior and read-only backlink discovery. All note moves use MCP `move_note` plus explicit backlink repair.
 - **Git CLI** for sync, backup, and versioning actions.
 
 ### Preflight checks before sync
@@ -84,7 +93,7 @@ Skill: Done. Vault synced to origin/main. No force push used.
 
 **MCP Server** — Handles all file I/O: reading, writing, searching, patching, and organizing notes. Enforces path sandboxing, validates inputs, and performs atomic operations. The safe default for any vault mutation.
 
-**Obsidian CLI** — Uses Obsidian's official CLI for operations that need the running desktop app: active file, opening notes in the editor, daily notes with template expansion, backlinks, plugin commands, and link-aware moves that update every reference. The skill tracks the current official CLI — a preflight detects your installed binary at runtime, so nothing is pinned to a version that can go stale.
+**Obsidian CLI** — Uses Obsidian's official CLI for operations that need the running desktop app: active file, opening notes in the editor, daily notes with template expansion, read-only backlink discovery, and plugin commands. The skill tracks the current official CLI — a preflight detects your installed binary at runtime, so nothing is pinned to a version that can go stale.
 
 **Git Sync** — Plain git for vault syncing across devices. No Obsidian Sync subscription required. Works headlessly via cron, launchd, or CI — no app needs to be running.
 
@@ -138,7 +147,7 @@ Recommended .gitignore:
 - "what links to this note?" -> Obsidian CLI
 - "sync my vault" -> Git CLI
 - "use git to store my vault" -> Git CLI
-- "move this note to..." -> Obsidian CLI (app running), MCP when headless
+- "move this note to..." -> MCP `move_note`, then explicit backlink repair and verification
 
 **Not a fit for:**
 - General markdown editing (no vault context)
@@ -199,7 +208,7 @@ description: >
   operations across MCP, Obsidian CLI/app
   actions, and git sync with safe defaults.
 metadata:
-  version: "2.1"
+  version: "2.2"
   author: bitbonsai
 ---
 ```

--- a/website/src/components/SkillsContent.astro
+++ b/website/src/components/SkillsContent.astro
@@ -37,11 +37,11 @@ const routes = [
     notes: 'Safe YAML merge',
   },
   {
-    operation: 'Move / rename files',
+    operation: 'Move / rename notes',
     mcp: true,
-    app: true,
+    app: false,
     git: false,
-    notes: 'CLI move rewrites internal links (app running); MCP move works headless',
+    notes: 'MCP move followed by explicit backlink search, repair, and verification',
   },
   {
     operation: 'Open note in Obsidian',
@@ -130,7 +130,7 @@ const triggers = [
   { phrase: 'open this note in Obsidian', backend: 'Obsidian CLI' },
   { phrase: 'sync my vault', backend: 'Git CLI' },
   { phrase: 'use git to store my vault', backend: 'Git CLI' },
-  { phrase: 'move this note to...', backend: 'Obsidian CLI, MCP when app is closed' },
+  { phrase: 'move this note to...', backend: 'MCP + backlink repair' },
 ];
 
 const syncFlow = [
@@ -343,10 +343,20 @@ const installCmd = 'npx skills add bitbonsai/mcpvault';
           <div>
             <h4 class="text-lg font-semibold text-foreground mb-3">Routing defaults</h4>
             <ul class="space-y-2 text-sm text-muted-foreground">
-              <li class="flex items-start gap-2"><span class="text-accent/60 mt-0.5">-</span><span><strong class="text-foreground">MCP first</strong> for read/write/search/frontmatter/tags.</span></li>
-              <li class="flex items-start gap-2"><span class="text-accent/60 mt-0.5">-</span><span><strong class="text-foreground">Obsidian context</strong> for app/editor/plugin-specific behavior, and for move/rename while the app is running — the CLI rewrites internal links that a filesystem move would leave stale (MCP is the headless fallback).</span></li>
+              <li class="flex items-start gap-2"><span class="text-accent/60 mt-0.5">-</span><span><strong class="text-foreground">MCP first</strong> for read/write/search/frontmatter/tags and all note moves.</span></li>
+              <li class="flex items-start gap-2"><span class="text-accent/60 mt-0.5">-</span><span><strong class="text-foreground">Obsidian context</strong> for app/editor/plugin-specific behavior and read-only backlink discovery.</span></li>
               <li class="flex items-start gap-2"><span class="text-accent/60 mt-0.5">-</span><span><strong class="text-foreground">Git CLI</strong> for sync, backup, and versioning actions.</span></li>
             </ul>
+          </div>
+          <div>
+            <h4 class="text-lg font-semibold text-foreground mb-3">Safe note rename flow</h4>
+            <ol class="space-y-2 text-sm text-muted-foreground list-decimal pl-5">
+              <li>Search for the old wikilink target by vault-relative path and filename stem.</li>
+              <li>Move the note with MCP <code>move_note</code>, even when Obsidian is running.</li>
+              <li>Patch exact wikilink targets while preserving aliases, embeds, and heading or block fragments.</li>
+              <li>Search again and report stale references. Do not claim exhaustive repair if the 20-result cap is reached or the basename is ambiguous.</li>
+            </ol>
+            <p class="text-xs text-muted-foreground mt-3">The skill does not invoke <code>obsidian move</code> automatically. Delayed stale-offset rewrites can corrupt notes edited while the command is still running (<a href="https://github.com/bitbonsai/mcpvault/issues/176" target="_blank" rel="noopener noreferrer" class="text-accent hover:underline">#176</a>).</p>
           </div>
           <div>
             <h4 class="text-lg font-semibold text-foreground mb-3">Preflight checks before sync</h4>
@@ -389,7 +399,7 @@ git remote -v</code></pre>
         <div class="bg-card/30 backdrop-blur-xl rounded-2xl border border-border/50 p-8">
           <h3 class="text-xl font-semibold text-foreground mb-3">Obsidian CLI</h3>
           <p class="text-muted-foreground">
-            Uses Obsidian's official CLI for operations that need the running desktop app: active file, opening notes in the editor, daily notes with template expansion, backlinks, plugin commands, and link-aware moves that update every reference. The skill tracks the current official CLI — a preflight detects your installed binary at runtime, so nothing is pinned to a version that can go stale.
+            Uses Obsidian's official CLI for operations that need the running desktop app: active file, opening notes in the editor, daily notes with template expansion, read-only backlink discovery, and plugin commands. The skill tracks the current official CLI — a preflight detects your installed binary at runtime, so nothing is pinned to a version that can go stale.
           </p>
         </div>
         <div class="bg-card/30 backdrop-blur-xl rounded-2xl border border-border/50 p-8">
@@ -587,7 +597,7 @@ description: >
   operations across MCP, Obsidian CLI/app
   actions, and git sync with safe defaults.
 metadata:
-  version: "2.0"
+  version: "2.2"
   author: bitbonsai
 ---</code></pre>
           </div>


### PR DESCRIPTION
## Summary

- route every note move through MCP `move_note`, even when Obsidian is running
- add an explicit search → move → backlink repair → verification workflow with honest handling of the 20-result search cap
- stop automatic use of `obsidian move` after the delayed stale-offset corruption report
- discover registered vault names with `obsidian vaults` instead of inferring from the folder basename
- sync the rich website and Markdown skill documentation; bump the skill metadata to 2.2

Closes #176.

## Safety rationale

The Obsidian CLI can complete backlink rewrites long after the filesystem move and apply offsets captured before intervening edits. A retry can double-apply, and a delayed write can silently replace unrelated Markdown. MCP's move is predictable; backlink repair is now separate, explicit, and verified rather than claimed implicitly.

## Validation

- `git diff --check`
- `cd website && bun install --frozen-lockfile && bun run build`
- Astro check: 0 errors (one pre-existing unused-variable hint)
