### PR TITLE
style(website): polish inline code

### DIFF
--- a/website/public/index.md
+++ b/website/public/index.md
@@ -11,7 +11,7 @@ This MCP server lets Claude, ChatGPT+, and other assistants access your vault. L
 
 ## Announcement
 
-- **The [latest MCP spec](https://modelcontextprotocol.io/specification/latest) is here.** We’re getting MCPVault ready for it. [View feat/mcp-sdk-v2](https://github.com/bitbonsai/mcpvault/tree/feat/mcp-sdk-v2).
+- **The [latest MCP spec](https://modelcontextprotocol.io/specification/latest) is out.** We’re getting MCPVault ready for it. [View feat/mcp-sdk-v2](https://github.com/bitbonsai/mcpvault/tree/feat/mcp-sdk-v2).
 - **JUST LAUNCHED - Obsidian Skill:** Smart routing across MCP, Obsidian app context, and Git CLI sync is now live, with preflight checks, targeted setup questions, and safe sync defaults. [See skill flows](/skill.md)
 
 ## Recent Updates

--- a/website/src/components/SpecPreviewCallout.astro
+++ b/website/src/components/SpecPreviewCallout.astro
@@ -6,24 +6,31 @@ const branchUrl = 'https://github.com/bitbonsai/mcpvault/tree/feat/mcp-sdk-v2';
 ---
 
 <section class="spec-preview relative px-4 pb-4 sm:px-6 lg:px-8" aria-label="Latest MCP specification development preview">
-  <div class="mx-auto max-w-6xl">
+  <div class="mx-auto max-w-4xl">
     <div class="spec-preview-card relative overflow-hidden rounded-xl border border-border/60 bg-card/70 px-5 py-4">
-      <div class="relative z-10 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div class="flex items-center gap-3">
+      <div class="relative z-10 flex items-center justify-between gap-3">
+        <div class="flex min-w-0 items-center gap-3">
           <div class="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg border border-accent/30 bg-accent/15">
             <GitBranch className="h-4 w-4 text-accent" aria-hidden="true" />
           </div>
 
           <p class="text-sm leading-relaxed text-muted-foreground">
             <span class="font-semibold text-foreground">
-              The <a href={specUrl} target="_blank" rel="noopener noreferrer" class="spec-link">latest MCP spec</a> is here.
+              The <a href={specUrl} target="_blank" rel="noopener noreferrer" class="spec-link">latest MCP spec</a> is out.
             </span>
-            We’re getting MCPVault ready for it.
+            <span class="sm:hidden"> We’re getting ready for it.</span>
+            <span class="hidden sm:inline"> We’re getting MCPVault ready for it.</span>
           </p>
         </div>
 
-        <a href={branchUrl} target="_blank" rel="noopener noreferrer" class="work-link flex flex-shrink-0 items-center gap-2 text-sm font-semibold text-accent transition-colors">
-          View <span>feat/mcp-sdk-v2</span>
+        <a
+          href={branchUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="View the feat/mcp-sdk-v2 branch"
+          class="work-link inline-flex h-10 w-10 flex-shrink-0 items-center justify-center gap-2 rounded-lg border border-accent/25 bg-accent/10 text-sm font-semibold text-accent transition-colors hover:border-accent/45 hover:bg-accent/20 sm:w-auto sm:px-3"
+        >
+          <span class="hidden sm:inline">View feat/mcp-sdk-v2</span>
           <ArrowRight className="h-4 w-4" aria-hidden="true" />
         </a>
       </div>
@@ -66,9 +73,4 @@ const branchUrl = 'https://github.com/bitbonsai/mcpvault/tree/feat/mcp-sdk-v2';
     outline-offset: 3px;
   }
 
-  @media (max-width: 640px) {
-    .work-link {
-      padding-left: 3rem;
-    }
-  }
 </style>

--- a/website/src/layouts/Layout.astro
+++ b/website/src/layouts/Layout.astro
@@ -116,6 +116,19 @@ const fullTitle = title.includes("MCPVault") ? title : `${title} | MCPVault`;
       #main-content {
         scroll-margin-top: 6rem;
       }
+
+      /* GFM-style inline code without affecting fenced code blocks or terminals. */
+      :where(p, li, td, dd, figcaption) > code {
+        padding: 0.14em 0.42em;
+        border: 1px solid rgba(148, 163, 184, 0.14);
+        border-radius: 0.45rem;
+        background: rgba(148, 163, 184, 0.1);
+        color: rgba(226, 232, 240, 0.96);
+        font-family: 'JetBrains Mono', 'SF Mono', 'Consolas', 'Liberation Mono', 'Menlo', monospace;
+        font-size: 0.88em;
+        box-decoration-break: clone;
+        -webkit-box-decoration-break: clone;
+      }
     </style>
 
     <!-- Terminal Styles -->


### PR DESCRIPTION
## Summary

- give prose-level inline `<code>` a subtle GFM-style background and border
- add compact padding and rounder corners
- preserve fenced code blocks, terminals, and standalone command components
- use cloned box decoration so wrapped inline code keeps its treatment cleanly

## Validation

- `cd website && bun install --frozen-lockfile && bun run build`
- Astro check: 0 errors (one pre-existing unused-variable hint)
- browser review at 1280×900 on the homepage update callout
