### PR TITLE
Standardize GitHub release publishing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@ npm test -- -t "test name pattern"
 
 # Publishing
 npm run publish:dry     # Dry run
-npm run publish:beta    # Publish with beta tag
-npm run publish:latest  # Publish as latest
+npm run publish:beta    # Explicit beta publish
+# Production: follow RELEASING.md and create a GitHub Release
 
 # Website
 npm run website         # Start Astro dev server with Bun (http://localhost:4321)
@@ -143,3 +143,4 @@ When modifying file operations:
 - Root server uses npm + `package-lock.json`; website uses Bun separately with committed `website/bun.lock`. Root `bun.lock` becomes stale/misleading; do not recreate.
 - MCP SDK v2 uses split `@modelcontextprotocol/server`, `/client`, `/core`, `/node` packages. `@modelcontextprotocol/sdk@latest` remains v1.x.
 - Version bump updates website nav/Hero automatically only. Manually sync `website/src/components/UpdateCallout.astro`, `website/public/index.md`, and `CHANGELOG.md`.
+- Production npm publishing is triggered by a GitHub Release and runs with provenance. Follow `RELEASING.md`; do not manually run `npm publish` for normal production releases, and do not backfill a release for an npm version that already exists.

--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,8 @@ This MCP server implements several security measures to protect your Obsidian va
 4. Ensure all tests pass: `npm test`
 5. Submit a pull request
 
+Maintainers: production publishing is driven by GitHub Releases. See [RELEASING.md](RELEASING.md).
+
 ## License
 
 MIT

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,64 @@
+# Releasing MCPVault
+
+Production releases are created through GitHub Releases. Publishing a release triggers `.github/workflows/publish.yml`, which tests, builds, and publishes the matching package version to npm with provenance.
+
+Do not backfill a GitHub Release for `0.15.0`: that version was published manually, and publishing a release now would trigger a duplicate npm publish. Start this process with the next version.
+
+## 1. Prepare the release in a PR
+
+The release PR must contain every artifact users will receive:
+
+- the semver bump in `package.json` and `package-lock.json`
+- source and tests
+- rebuilt `dist/` from the same source
+- `CHANGELOG.md`
+- website release history in both `website/src/components/UpdateCallout.astro` and `website/public/index.md`
+- any feature documentation in both browser and Markdown formats
+
+Run the root tests, build, audit, dry-run package, and website build before merging.
+
+## 2. Verify main
+
+After the release PR merges, wait for required main checks to pass. Confirm the intended version is not already on npm:
+
+```bash
+VERSION=$(node -p "require('./package.json').version")
+npm view "@bitbonsai/mcpvault@$VERSION" version
+```
+
+A not-found response is expected before publishing. Stop if npm already has the version.
+
+## 3. Publish a GitHub Release
+
+Write concise release notes from the matching changelog entry, then create the release. This command creates the `vX.Y.Z` tag at the selected main commit and publishes the GitHub Release:
+
+```bash
+VERSION=$(node -p "require('./package.json').version")
+gh release create "v$VERSION" \
+  --repo bitbonsai/mcpvault \
+  --target main \
+  --title "v$VERSION" \
+  --notes-file /tmp/mcpvault-release-notes.md
+```
+
+Do not use generated notes for the first GitHub Release because the repository has no historical release tags; use the curated changelog entry instead.
+
+## 4. Verify publication
+
+Watch the `Publish` workflow and verify npm after it succeeds:
+
+```bash
+gh run list --repo bitbonsai/mcpvault --workflow Publish --limit 1
+npm view @bitbonsai/mcpvault version
+npx --yes "@bitbonsai/mcpvault@$VERSION" --version
+```
+
+Confirm the GitHub Release tag, npm version, installed CLI version, and website release copy all agree before considering the release complete.
+
+## Failure handling
+
+- npm versions are immutable. Never bump or republish the same version after a partial failure.
+- If the workflow fails before npm publication, fix the workflow and rerun it.
+- If npm already shows the version, do not rerun the publish step; verify the package and repair only the missing release metadata.
+- `npm run publish:latest` is an emergency fallback, not the normal production path. It does not provide the GitHub Release-driven provenance flow.
+- Beta publishing remains explicit through `npm run publish:beta`; do not create a production GitHub Release for an unapproved beta.

--- a/skills/triage/SKILL.md
+++ b/skills/triage/SKILL.md
@@ -168,22 +168,26 @@ Do NOT bump for changes that do not ship: lockfile-only updates (e.g. a bare
 `npm audit fix`), docs, CI config, tests-only, or anything under `.triage/`.
 When unsure whether a change ships, do not bump; note it in the inbox.
 
-**Publishing is always manual.** The loop NEVER runs `npm publish`. After a PR
-that includes a version bump, write a top-of-inbox alert:
+**Publishing is always maintainer-triggered.** The loop NEVER runs `npm publish`
+or creates a GitHub Release. After a PR that includes a version bump, write a
+top-of-inbox alert:
 
 ```
-## PUBLISH NEEDED
-- PR #<n> bumps <old> -> <new> (<reason>). After it merges, run `npm publish`
-  manually. Loop does not publish.
+## RELEASE NEEDED
+- PR #<n> bumps <old> -> <new> (<reason>). After it merges and main is green,
+  follow RELEASING.md and create GitHub Release v<new>. The release workflow
+  publishes npm with provenance; the loop does not publish.
 ```
 
-Keep the alert until the maintainer confirms it shipped.
+Keep the alert until the GitHub Release, npm package, and installed-package
+smoke test are all confirmed.
 
 ## Guardrails
 
 - Never push to `main`, never merge, never `--force`. PRs only.
-- Never run `npm publish`. Version bumps ride inside the fix PR; publishing is
-  the maintainer's manual step, flagged via the inbox PUBLISH NEEDED alert.
+- Never run `npm publish` or create a GitHub Release. Version bumps ride inside
+  the fix PR; the maintainer creates the release after merge, flagged via the
+  inbox RELEASE NEEDED alert. Follow `RELEASING.md`.
 - Never touch files outside the worktree except `.triage/`.
 - The token usually lacks the GitHub `workflow` scope, so pushes that change
   `.github/workflows/*` are rejected. Do NOT attempt them; route any CI/workflow


### PR DESCRIPTION
## Summary

- document GitHub Releases as the normal production release entrypoint
- keep release preparation, main verification, npm provenance publication, and installed-package verification in one checklist
- update maintainer and triage guidance so the loop raises `RELEASE NEEDED` instead of asking for manual `npm publish`
- explicitly avoid backfilling v0.15.0, which is already on npm

The existing release workflow is ready and its encrypted `NPM_TOKEN` Actions secret is now configured. No release or tag is created by this PR.

## Validation

- existing `.github/workflows/publish.yml` triggers on published GitHub Releases and publishes with provenance
- npm authentication verified as `bitbonsai`
- repository Actions secret presence verified without exposing its value
- `git diff --check`
