### PR TITLE
Restore extensionless website routes

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -6,6 +6,7 @@ import tailwindcss from '@tailwindcss/vite';
 // https://astro.build/config
 export default defineConfig({
   adapter: cloudflare(),
+  trailingSlash: 'always',
   integrations: [react()],
   build: {
     inlineStylesheets: 'always' // Inline all CSS to prevent render blocking


### PR DESCRIPTION
## Summary

- configure Astro's canonical trailing-slash behavior after the Astro 7 migration
- restore direct requests such as `/install`, `/features`, and `/demo` by redirecting them to their prerendered `/.../` routes

## Validation

- reproduced production 404s for every direct extensionless page while the trailing-slash routes returned 200
- `bun install --frozen-lockfile`
- `bun run build` — 0 errors, 0 warnings, 0 hints
- local Cloudflare preview: `/install` and `/features` return 307 to the slash route; targets return 200
- `git diff --check`
