### PR TITLE
Add explicit Cloudflare route and indexing rules

### DIFF
--- a/website/public/_headers
+++ b/website/public/_headers
@@ -1,0 +1,2 @@
+/*
+  X-Robots-Tag: index, follow

--- a/website/public/_redirects
+++ b/website/public/_redirects
@@ -1,0 +1,5 @@
+/install         /install/         301
+/features        /features/        301
+/demo            /demo/            301
+/how-it-works    /how-it-works/    301
+/skill           /skill/           301


### PR DESCRIPTION
## Summary

- add Cloudflare Pages redirects from extensionless public routes to their prerendered trailing-slash pages
- explicitly allow production indexing with `X-Robots-Tag: index, follow`

This complements Astro's canonical trailing-slash setting: Astro preview redirected correctly, but the production custom domain's static asset layer bypassed the router and returned 404 for `/install`, `/features`, and the other extensionless routes.

## Validation

- reproduced production 404s on all five extensionless routes
- `bun install --frozen-lockfile`
- `bun run build` — 0 errors, 0 warnings, 0 hints; parses all five redirect rules and the header rule
- local Cloudflare preview returns 301 for all five routes and `X-Robots-Tag: index, follow`
- slash targets return 200
- `git diff --check`
