### PR TITLE
docs: record shibumi migration plan, gotchas, and orchestration script

### DIFF
--- a/.claude/workflows/shibumi-migration.js
+++ b/.claude/workflows/shibumi-migration.js
@@ -1,0 +1,293 @@
+export const meta = {
+  name: 'shibumi-migration',
+  description: 'Phase-gated MCPVault website migration to Bun + Hono + Alpine on Hetzner',
+  whenToUse: 'Run one phase per invocation: args {phase: "p0".."p8"}. Optional args: worktree (path from p1), stagingUrl (p6), prodUrl (p7), hetznerHost (p0/p5). Review the gate report and get maintainer approval before the next phase.',
+  phases: [
+    { title: 'P0 Baseline' },
+    { title: 'P1 Skeleton' },
+    { title: 'P2 Pages' },
+    { title: 'P3 Interactivity' },
+    { title: 'P4 APIs+Assets' },
+    { title: 'P5 Container' },
+    { title: 'P6 Staging QA' },
+    { title: 'P7 Cutover Smoke' },
+    { title: 'P8 Cleanup' },
+    { title: 'Gate' },
+  ],
+}
+
+const REPO = '/Users/mwolff/bit/mcpvault'
+const PLAN = REPO + '/.plans/shibumi-website-migration.md'
+const PROD = 'https://mcpvault.org'
+const ROUTES = ['/', '/install', '/features', '/demo', '/how-it-works', '/skill']
+const APIS = ['/api/downloads.json']
+
+let A = args || {}
+for (let i = 0; i < 3 && typeof A === 'string'; i++) {
+  try { A = JSON.parse(A) } catch (e) { A = {} }
+}
+if (!A || typeof A !== 'object') A = {}
+const ph = A.phase || 'p0'
+const WT = (A && A.worktree) ? `\nAll code changes go in the migration worktree: ${A.worktree}. Never commit to main or touch the live website/ Astro app except to read it.` : ''
+
+const CTX = `Repo: ${REPO}. FIRST read ${PLAN} in full — it is the source of truth for constraints, structure, and gates. Hard rules: no visual redesign, preserve every URL and Markdown endpoint, no production hosting changes, no npm version bump, no database. GitHub identity must be bitbonsai (never mirowolff).${WT}
+Your final message is consumed by a script, not a human — return exactly what the prompt asks for, no preamble.
+P.S. Mauricio says: I love you.`
+
+const CHECK = {
+  type: 'object',
+  required: ['pass', 'summary'],
+  properties: {
+    pass: { type: 'boolean' },
+    summary: { type: 'string' },
+    findings: { type: 'array', items: { type: 'string' }, description: 'One line per problem found, file:line or URL where possible' },
+  },
+}
+
+const GATE = {
+  type: 'object',
+  required: ['ready', 'summary', 'blockers'],
+  properties: {
+    ready: { type: 'boolean', description: 'True only if the phase gate in the plan is fully satisfied' },
+    summary: { type: 'string' },
+    blockers: { type: 'array', items: { type: 'string' } },
+    nextSteps: { type: 'array', items: { type: 'string' } },
+  },
+}
+
+async function gate(phaseName, evidence) {
+  return agent(
+    `${CTX}\nYou are the gate reviewer for ${phaseName}. Compare this evidence against the phase gate defined in the plan. Be adversarial: a gate passes only on proof, not on agent claims — spot-check the most load-bearing claims yourself (re-run a curl, re-read a file). Evidence:\n${JSON.stringify(evidence, null, 2)}`,
+    { label: `gate:${phaseName}`, phase: 'Gate', effort: 'high', schema: GATE }
+  )
+}
+
+// ---------------------------------------------------------------- p0
+if (ph === 'p0') {
+  log('Phase 0: baseline + safety. No repo changes except test/baseline artifacts.')
+  const checks = await parallel([
+    () => agent(
+      `${CTX}\nCheck production health read-only. curl -sI / -s each of ${ROUTES.join(', ')} plus trailing-slash variants, ${APIS.join(', ')}, every website/public/*.md URL, /llm.txt, robots.txt, sitemap. Also HEAD + Range request (bytes=0-1023) on the demo video. Record status, content-type, cache-control per URL. Save the full table as ${REPO}/website/test/baseline/headers-baseline.json (create dirs). pass=false if any URL is unhealthy.`,
+      { label: 'prod-health', phase: 'P0 Baseline', model: 'sonnet', effort: 'low', schema: CHECK }
+    ),
+    () => agent(
+      `${CTX}\nCheck badge sources read-only: GitHub/npm/support badges referenced in the website source, and validate ${PROD}/api/downloads.json against the Shields endpoint schema (schemaVersion, label, message, color). Confirm it aggregates both npm package names. pass=false on any broken badge or schema drift.`,
+      { label: 'badges', phase: 'P0 Baseline', model: 'sonnet', effort: 'low', schema: CHECK }
+    ),
+    () => agent(
+      `${CTX}\nUse the agent-browser skill to capture deterministic baseline screenshots of ${PROD}${ROUTES.join(', ' + PROD)} at 1440x900 and 390x844. Disable animations via prefers-reduced-motion / injected CSS, let the video sit on its poster frame, and note (do not mask yet) any live counters. Save PNGs under ${REPO}/website/test/visual/baseline/ named route-viewport.png. Afterwards close the session and kill Chrome for Testing helpers: pkill -f '/[a]gent-browser-darwin-arm64'; pkill -f '[G]oogle Chrome for Testing'; verify with pgrep. pass=false if any screenshot failed.`,
+      { label: 'baseline-shots', phase: 'P0 Baseline', model: 'sonnet', effort: 'medium', schema: CHECK }
+    ),
+    () => agent(
+      `${CTX}\nReport read-only status of PR #190 (gh pr view 190: state, reviews, CI). Do NOT merge — merging is the maintainer's call. Also run a Lighthouse or equivalent accessibility/performance snapshot of ${PROD}/ if a tool is available locally, and store results under ${REPO}/website/test/baseline/. pass=false if PR #190 is unmerged (it is a plan gate) — list it as a finding, not something to fix.`,
+      { label: 'pr190+lighthouse', phase: 'P0 Baseline', model: 'sonnet', effort: 'low', schema: CHECK }
+    ),
+    () => (A && A.hetznerHost)
+      ? agent(
+          `${CTX}\nAudit the Hetzner host ${A.hetznerHost} over SSH READ-ONLY (uname, os-release, existing reverse proxy config, TLS ownership, rootless podman + systemd/quadlet conventions, listening ports, firewall, df -h, free -m, Cloudflare origin setup). Change nothing. Return findings and note which reverse-proxy/deploy convention the plan's open decision should adopt.`,
+          { label: 'hetzner-audit', phase: 'P0 Baseline', model: 'sonnet', effort: 'medium', schema: CHECK }
+        )
+      : Promise.resolve({ pass: false, summary: 'Hetzner audit skipped: pass args.hetznerHost to run it.', findings: ['hetzner host audit not run'] }),
+  ])
+  log('Baseline checks done — running gate review.')
+  const g = await gate('Phase 0', checks.filter(Boolean))
+  return { phase: 'p0', checks: checks.filter(Boolean), gate: g }
+}
+
+// ---------------------------------------------------------------- p1
+if (ph === 'p1') {
+  log('Phase 1: parallel Shibumi skeleton in a dedicated worktree.')
+  const skeleton = await agent(
+    `${CTX}\ngit fetch origin first, then create the migration branch shibumi based on origin/main in a NEW worktree using the wt CLI (worktrunk; fall back to git worktree add if wt is unavailable) — local main may be behind and must not be checked out or modified. Inside it, scaffold the Shibumi app per the plan's "Proposed website structure" section in a new website-shibumi/ directory alongside the live website/: Bun + Hono, server.ts with /healthz, static serving, security headers, request logging, graceful shutdown, error handling; a dedicated video route per the plan's Phase 1 item 6 built on Bun.file(path).slice(start, end) handling HEAD, full GET, and Range with correct 206/Content-Range/Accept-Ranges plus tests against a >5MB fixture (decided: do NOT use hono serveStatic for video, its Bun Range support has been incomplete); bun.lock committed; route tests with bun:test using app.request(); Containerfile; CI job using bun install --frozen-lockfile that does NOT touch the existing website deploy workflow. No pages yet. Also copy the untracked Phase 0 baseline artifacts from the main checkout (${REPO}/website/test/visual/baseline/*.png, ${REPO}/website/test/baseline/*) into the same paths in the worktree and commit them — the plan requires baselines stored in the repo. Run bun test and bun audit. Commit as bitbonsai. Return the absolute worktree path on the first line, then what you built and test results.`,
+    { label: 'skeleton', phase: 'P1 Skeleton', effort: 'high' }
+  )
+  const worktree = (skeleton || '').split('\n')[0].trim()
+  const [review, container] = await parallel([
+    () => agent(
+      `${CTX}\nReview the skeleton commit(s) on shibumi in worktree ${worktree} (git log/show). Check: security headers sane, graceful shutdown real (SIGTERM handled, in-flight requests drain), video route returns correct 206/Content-Range for Range and open-ended Range requests, no secrets anywhere, lockfile committed, tests meaningful, CI isolated from the live Astro deploy. Findings one line each, severity-tagged.`,
+      { label: 'review:skeleton', phase: 'P1 Skeleton', effort: 'high', schema: CHECK }
+    ),
+    () => agent(
+      `${CTX}\nIn worktree ${worktree}: build the container image and smoke-test it. podman is NOT installed on this Mac — use docker (colima is running, docker daemon confirmed working); the Containerfile must stay podman-compatible for the Hetzner host, docker is only the local test runtime (docker build -f Containerfile). Run the container, curl /healthz, send SIGTERM and confirm clean shutdown, then remove the container and image. pass=false on any failure with exact error output.`,
+      { label: 'container-smoke', phase: 'P1 Skeleton', model: 'sonnet', effort: 'medium', schema: CHECK }
+    ),
+  ])
+  const g = await gate('Phase 1', { review, container })
+  return { phase: 'p1', worktree, review, container, gate: g }
+}
+
+// ---------------------------------------------------------------- p2
+if (ph === 'p2') {
+  if (!A || !A.worktree) return { error: 'Pass args.worktree (from p1 result).' }
+  const GROUPS = [
+    { name: 'shell', routes: [], detail: 'Layout.tsx, Nav, Footer, ThemeToggle markup, head metadata, canonical URLs, Open Graph, structured data, sitemap + robots routes', effort: 'high' },
+    { name: 'home', routes: ['/'], detail: 'Hero, FeatureGrid, FeatureCard, CodeExample, CodeBlock (server-side Shiki cached at startup), FAQ, UpdateCallout, SpecPreviewCallout, NewsletterSignup markup. One deliberate content fix found in Phase 0: the npm downloads badge anchor (Hero.astro:151) links to the nonexistent unscoped https://www.npmjs.com/package/mcpvault — port it pointing at https://www.npmjs.com/package/@bitbonsai/mcpvault instead. Also apply the shell-review carry-overs in this same commit: port the Counter.dev analytics script from website/src/layouts/Layout.astro:497-498 into Layout.tsx (MEDIUM finding — silently dropped); restore the "# LLM-specific crawlers" comment in the generated robots.txt (src/routes/seo.ts:33); make footer gutters responsive like Footer.astro px-4 sm:px-6 lg:px-8 (shared.css:325 is fixed 4rem 1rem); scope body overflow-x:hidden to the home page only, not globally (shared.css:49); remove the dead class="theme-toggle" from ThemeToggle.tsx or root its CSS on it, one convention only', effort: 'high' },
+    { name: 'features', routes: ['/features/'], detail: 'ComparisonTable and features content', effort: 'medium' },
+    { name: 'install', routes: ['/install/'], detail: 'Terminal markup and tab/copy structure (Alpine behavior lands in Phase 3)', effort: 'high' },
+    { name: 'how-it-works', routes: ['/how-it-works/'], detail: 'HowItWorks', effort: 'medium' },
+    { name: 'skill', routes: ['/skill/'], detail: 'SkillsContent', effort: 'high' },
+    { name: 'demo', routes: ['/demo/'], detail: 'InteractiveDemo/ResponseRenderer static shell only, interactivity in Phase 3', effort: 'medium' },
+  ]
+  const done = []
+  for (const grp of GROUPS) {
+    log(`Porting group: ${grp.name}`)
+    const port = await agent(
+      `${CTX}\nPort group "${grp.name}" (${grp.detail}) from the Astro site at ${REPO}/website/src into the Hono/Bun app per the plan's Phase 2 rules: TSX markup via Hono JSX (audit every raw-HTML use), page + component CSS converted from Tailwind/Astro-scoped styles into the plan's data-component/page-root convention, Markdown counterpart preserved, lucide-react icons replaced with inline SVG helper preserving aria attributes. Add bun:test route assertions for the affected routes (status, key content, content negotiation). Run bun test. Commit as bitbonsai. Return files touched and test results.`,
+      { label: `port:${grp.name}`, phase: 'P2 Pages', model: 'sonnet', effort: grp.effort }
+    )
+    // Visual verification happens live: the maintainer has both sites open (prod +
+    // localhost:8788 watch server) and eyeballs each group as it commits. One full
+    // automated pixel pass still runs later in the QA phase.
+    done.push({ group: grp.name, port })
+    log(`Group ${grp.name} committed — testable now at http://localhost:8788${(grp.routes && grp.routes[0]) || '/'}`)
+  }
+  const review = await agent(
+    `${CTX}\nReview all Phase 2 commits on shibumi in worktree ${A.worktree}. Focus: raw-HTML/escaping boundaries, no leftover Tailwind classes, CSS rooted per the component-namespace convention, URLs and metadata unchanged vs the Astro source, no-JS rendering intact. Findings one line each, severity-tagged.`,
+    { label: 'review:pages', phase: 'P2 Pages', effort: 'high', schema: CHECK }
+  )
+  const g = await gate('Phase 2', { groups: done, review })
+  return { phase: 'p2', groups: done, review, gate: g }
+}
+
+// ---------------------------------------------------------------- p3
+if (ph === 'p3') {
+  if (!A || !A.worktree) return { error: 'Pass args.worktree.' }
+  const steps = [
+    { name: 'demo', prompt: 'Port InteractiveDemo.tsx and ResponseRenderer.tsx to Alpine named modules (Alpine.data) in src/client/. Vendor the @alpinejs/csp build locally (no CDN, no standard Alpine build) — the CSP build forbids inline expressions, so attributes may only name registered modules/methods. If a piece of the demo is genuinely impossible under that restriction, stop and report it as a blocker instead of silently switching builds. Preserve response rendering exactly.', effort: 'high' },
+    { name: 'chrome-behaviors', prompt: 'Port navigation (mobile menu), theme toggle with persistence, Terminal tab/copy behavior, and newsletter submission UI states to Alpine named modules. For the Terminal (maintainer decisions: demo-purpose, keep it simple): add a lightweight typing animation for the command lines and keep per-tab state (selected tab, animation progress) in the component Alpine.data scope or a shared Alpine.store — do NOT add nanostores or any second state library; Alpine is the single state layer. Also port the .fade-in-on-scroll behavior properly: production animates it via a JS IntersectionObserver on scroll, but the p2 CSS made it auto-animate on features/install; wire the observer (plain JS module, no Alpine needed) and root the currently un-rooted duplicated .fade-in-on-scroll class per the CSS scoping convention (or document it as a shared helper in shared.css).', effort: 'medium' },
+    { name: 'view-transitions', prompt: 'Add native cross-document View Transitions (@view-transition { navigation: auto; }) with reduced-motion fallback. No SPA router.', effort: 'medium' },
+  ]
+  const ported = []
+  for (const s of steps) {
+    ported.push({
+      step: s.name,
+      result: await agent(`${CTX}\n${s.prompt} All logic lives in named Alpine.data() modules — the vendored @alpinejs/csp build cannot evaluate inline expressions. Add or update tests where testable server-side. Run bun test. Commit as bitbonsai.`,
+        { label: `port:${s.name}`, phase: 'P3 Interactivity', model: 'sonnet', effort: s.effort }),
+    })
+  }
+  const [browser, cleanup] = await parallel([
+    () => agent(
+      `${CTX}\nFunctional browser test in worktree ${A.worktree}: start the dev server, use agent-browser at desktop and mobile widths to exercise mobile nav, theme toggle + persistence across navigation, interactive demo end-to-end, terminal copy, newsletter client-side validation states, back/forward history, deep links, keyboard operation and focus visibility, and confirm zero console errors. Also verify every page still renders with JavaScript disabled. Kill dev server and Chrome for Testing helpers afterwards. pass=false on any failure.`,
+      { label: 'browser-functional', phase: 'P3 Interactivity', model: 'sonnet', effort: 'high', schema: CHECK }
+    ),
+    () => agent(
+      `${CTX}\nIn worktree ${A.worktree}: confirm the new app has no React, no Astro client directives, no react-only deps in website-shibumi/package.json, and grep for leftover client:load/client:visible/useState imports. Report only — removal from the OLD website/ dir happens in Phase 8. pass=false if the new app still depends on React.`,
+      { label: 'dep-check', phase: 'P3 Interactivity', model: 'sonnet', effort: 'low', schema: CHECK }
+    ),
+  ])
+  const g = await gate('Phase 3', { ported, browser, cleanup })
+  return { phase: 'p3', ported, browser, cleanup, gate: g }
+}
+
+// ---------------------------------------------------------------- p4
+if (ph === 'p4') {
+  if (!A || !A.worktree) return { error: 'Pass args.worktree.' }
+  const apis = await parallel([
+    () => agent(
+      `${CTX}\nPort GET /api/downloads.json per the plan: exact Shields schema, totals for both npm package names, explicit upstream timeouts, bounded in-memory cache with last-known-value fallback, current cache headers preserved. Full bun:test coverage: success, timeout, partial upstream failure, cache hit, stale fallback. Commit as bitbonsai.`,
+      { label: 'api:downloads', phase: 'P4 APIs+Assets', model: 'sonnet', effort: 'high' }
+    ),
+    () => agent(
+      `${CTX}\nPort POST /api/subscribe per the plan: JSON + form-urlencoded parsing, Zod email validation/normalization, injectable Resend client, every {error} result checked, tracked (awaited or queued, never fire-and-forget) welcome email with an Idempotency-Key so retries cannot double-send, request size limit, secrets only via env. Full test coverage listed in the plan's test matrix. Commit as bitbonsai.`,
+      { label: 'api:subscribe', phase: 'P4 APIs+Assets', model: 'sonnet', effort: 'high' }
+    ),
+    () => agent(
+      `${CTX}\nPort GET /api/unsubscribe preserving current behavior exactly (signed tokens are a documented follow-up, do not add them). Tests: missing email, normalization, Resend error, successful removal. Commit as bitbonsai.`,
+      { label: 'api:unsubscribe', phase: 'P4 APIs+Assets', model: 'sonnet', effort: 'medium' }
+    ),
+  ])
+  const [assets, redirects, security] = await parallel([
+    () => agent(
+      `${CTX}\nVerify static parity AT CURRENT BRANCH HEAD (several header/Containerfile fix commits landed after the first pass — build fresh, do not reuse prior conclusions) in worktree ${A.worktree} against a locally running container: every website/public/*.md URL, llm.txt, media filenames, content types, cache headers, video HEAD + full GET + Range=bytes 206 responses through the Phase 1 dedicated video route. Compare headers against ${REPO}/website/test/baseline/headers-baseline.json and list every diff. pass=false on missing asset or header regression that matters (allow server-identity headers to differ).`,
+      { label: 'assets-parity', phase: 'P4 APIs+Assets', model: 'sonnet', effort: 'medium', schema: CHECK }
+    ),
+    () => agent(
+      `${CTX}\nTrailing-slash and redirect parity: read the Cloudflare route/redirect fixes from PRs #187 and #188 (gh pr view/diff) and the current production behavior for each route with and without trailing slash. The trailing-slash 301 middleware already exists in app.tsx (commit 069b9ee) — verify it against the PR rules rather than re-implementing. Then fix the confirmed header-parity drifts from the Phase 2 review, matching website/test/baseline/headers-baseline.json exactly: (a) .md static responses need "text/markdown; charset=utf-8" and "public, max-age=0, must-revalidate" (currently no charset + max-age=3600); (b) page HTML routes send no cache-control, baseline says "public, max-age=0, must-revalidate"; (c) decide /sitemap-0.xml (currently 404, production served it; serve the same XML or 301 to /sitemap.xml and record the deviation in the plan); (d) make robots.txt byte-identical to website/public/robots.txt; (e) fix src/lib/highlight.ts to actually cache Shiki output at startup as its doc comment claims (currently codeToHtml runs per request); (f) note the Cloudflare Pages _headers X-Robots-Tag "index, follow" dies at cutover — replicate it as a Hono header. Add tests. Commit as bitbonsai.`,
+      { label: 'redirect-parity', phase: 'P4 APIs+Assets', model: 'sonnet', effort: 'medium' }
+    ),
+    () => agent(
+      `${CTX}\nSecurity work + review of the new app in worktree ${A.worktree} at CURRENT branch HEAD. The CSP may already be implemented and committed (src/lib/csp.ts + secureHeaders wiring) — if so, verify it rather than re-implementing. Otherwise FIRST implement (not just review): an explicit Content-Security-Policy header — hono/secure-headers defaults emit NO CSP, so the @alpinejs/csp build's no-unsafe-eval benefit is currently unenforced. Write a strict policy (no unsafe-eval; account for the inline font-loader script + JSON-LD (nonce or hash or refactor), Google Fonts stylesheet, Counter.dev script, shields.io images, self video/styles/scripts), add tests asserting the header and that no unsafe-eval is present, verify every page still works in a real browser (agent-browser, own port, never 8788, sweep Chrome helpers after), commit as bitbonsai. THEN review: confirm the vendored Alpine is the @alpinejs/csp build (any inline x-data expression that forces the standard build is a finding); headers vs video, Shields fetches, Resend calls; CSRF posture for /api/subscribe documented; request size limits in the app plus a documented Cloudflare WAF rate rule for /api/subscribe; bun audit output; no secrets in code, image layers, or logs. Findings one line each, severity-tagged. pass=false on any high-severity finding.`,
+      { label: 'security-review', phase: 'P4 APIs+Assets', effort: 'high', schema: CHECK }
+    ),
+  ])
+  const g = await gate('Phase 4', { apis, assets, redirects, security })
+  return { phase: 'p4', apis, assets, redirects, security, gate: g }
+}
+
+// ---------------------------------------------------------------- p5
+if (ph === 'p5') {
+  if (!A || !A.worktree) return { error: 'Pass args.worktree. Pass args.hetznerHost to include the staging deploy.' }
+  const build = await agent(
+    `${CTX}\nHarden the container per the plan's Phase 5. Carry-forwards from the Phase 1 review: digest-pin the oven/bun base image (currently tag-pinned 1.3.14-alpine); add a bounded drain timeout to server.ts shutdown (then server.stop(true)) plus an automated shutdown-drain test; harden the publicDir prefix check in src/app.tsx against trailing-separator/relative paths. Then: minimal pinned Bun base image, non-root user, read-only rootfs where practical, dropped capabilities, no-new-privileges, 512MB memory + conservative CPU limits, /healthz health check, systemd Quadlet unit (or the host convention found in the Phase 0 audit). Add a GitHub Actions job publishing immutable commit-SHA-tagged images to GHCR as ghcr.io/bitbonsai/mcpvault-web (the app's name is mcpvault-web; no workflow-file changes to the existing website deploy). Verify the image locally: podman is NOT installed on this Mac, use docker via the running colima VM (docker build/run with equivalent flags: --read-only, --cap-drop=ALL, --security-opt no-new-privileges, --memory 512m, non-root user); keep the Quadlet unit and image podman-compatible for the Hetzner host. Check: non-root, read-only, healthcheck passing, clean SIGTERM. Commit as bitbonsai.`,
+    { label: 'container-harden', phase: 'P5 Container', model: 'sonnet', effort: 'high' }
+  )
+  const webhook = await agent(
+    `${CTX}\nBuild the deploy webhook receiver per the plan's "Deploy webhook" section: a small standalone Bun script (host systemd service, OUTSIDE the website container) that accepts GitHub workflow_run/package webhooks. Must: verify X-Hub-Signature-256 HMAC with constant-time comparison and reject with 401 before any side effects; filter on repo/workflow/branch/success; validate the commit SHA against ^[0-9a-f]{7,40}$ and never interpolate raw payload strings into shell commands; serialize deploys with a lock; podman pull the SHA tag, restart the Quadlet unit, poll /healthz, auto-rollback to the previous tag on timeout; read the webhook secret from a mode-0600 env file or systemd credential; log every attempt to journald. Full bun:test coverage for signature verification (valid, invalid, missing), payload filtering, SHA validation, and lock behavior with the podman calls stubbed. Write it as a self-contained module suitable for later upstreaming to shibumi-server. Commit as bitbonsai.`,
+    { label: 'deploy-webhook', phase: 'P5 Container', model: 'sonnet', effort: 'high' }
+  )
+  let deploy = { pass: false, summary: 'Staging deploy skipped: pass args.hetznerHost.', findings: [] }
+  if (A.hetznerHost) {
+    deploy = await agent(
+      `${CTX}\nDeploy the GHCR image to staging on ${A.hetznerHost} per the plan: rootless podman via Quadlet, Resend secrets via mode-0600 env file or systemd credentials (NEVER echo secret values, never write them into the repo or logs), staging hostname behind Cloudflare with Full (strict) TLS, no direct public origin exposure beyond the proxy path. Install the deploy webhook receiver as a host systemd service on its dedicated path, register the GitHub webhook (workflow_run completed, not push) with a fresh secret, and verify an end-to-end webhook-triggered redeploy including the auto-rollback path. Then verify: logs clean, container restarts after unit restart, health-check failure handling, and manual rollback to the previous image tag. pass=false with exact errors on any failure.`,
+      { label: 'staging-deploy', phase: 'P5 Container', model: 'sonnet', effort: 'high', schema: CHECK }
+    )
+  }
+  const g = await gate('Phase 5', { build, webhook, deploy })
+  return { phase: 'p5', build, webhook, deploy, gate: g }
+}
+
+// ---------------------------------------------------------------- p6
+if (ph === 'p6') {
+  if (!A || !A.stagingUrl) return { error: 'Pass args.stagingUrl (the deployed staging hostname — this phase must not run against localhost).' }
+  const S = A.stagingUrl
+  log(`Phase 6 QA against ${S}. All checks target the deployed host, not localhost.`)
+  const shotSuffix = `Afterwards close agent-browser sessions and kill Chrome for Testing helpers (pkill -f '/[a]gent-browser-darwin-arm64'; pkill -f '[G]oogle Chrome for Testing').`
+  const qa = await parallel([
+    () => agent(`${CTX}\nScreenshot ${S}${ROUTES.join(', ' + S)} at 1440x900 and 390x844 with agent-browser, deterministic (animations off, video on poster frame, mask live counters), and pixel-compare against ${REPO}/website/test/visual/baseline/. Save the new shots under website/test/visual/staging/. List every route with visible differences. ${shotSuffix}`, { label: 'qa:visual', phase: 'P6 Staging QA', model: 'sonnet', effort: 'medium', schema: CHECK }),
+    () => agent(`${CTX}\nOn ${S}: every route direct and with trailing slash, every public .md URL, llm.txt, robots, sitemap, structured data present in HTML, canonical URLs and OG metadata matching production values from the baseline. Compare response headers to website/test/baseline/headers-baseline.json.`, { label: 'qa:routes-meta', phase: 'P6 Staging QA', model: 'sonnet', effort: 'low', schema: CHECK }),
+    () => agent(`${CTX}\nOn ${S}: video poster, metadata, HEAD, Range request 206, and REAL playback in agent-browser (play, seek, confirm currentTime advances). All images, fonts, icons load with correct types. ${shotSuffix}`, { label: 'qa:video-assets', phase: 'P6 Staging QA', model: 'sonnet', effort: 'medium', schema: CHECK }),
+    () => agent(`${CTX}\nOn ${S}: GitHub/npm/support badges render, /api/downloads.json matches Shields schema and production values within reason. Newsletter subscribe happy path + validation/error paths using the controlled Resend test configuration ONLY (never the production audience); unsubscribe validation/error paths. pass=false if any API misbehaves.`, { label: 'qa:apis', phase: 'P6 Staging QA', model: 'sonnet', effort: 'medium', schema: CHECK }),
+    () => agent(`${CTX}\nOn ${S} with agent-browser: full keyboard navigation with visible focus on every interactive element, reduced-motion honored, theme toggle persists across navigation and reload, browser back/forward and deep links work, zero console and zero failed network requests across all six routes. ${shotSuffix}`, { label: 'qa:a11y-behavior', phase: 'P6 Staging QA', model: 'sonnet', effort: 'high', schema: CHECK }),
+    () => agent(`${CTX}\nOn ${S}: Cloudflare cache behavior (cf-cache-status per asset class), origin header hygiene, TLS mode evidence, and confirm the origin is not directly reachable except through the intended proxy path (test the origin IP/port from outside expectations documented in the plan; read-only).`, { label: 'qa:cloudflare', phase: 'P6 Staging QA', model: 'sonnet', effort: 'low', schema: CHECK }),
+  ])
+  const g = await gate('Phase 6', qa.filter(Boolean))
+  return {
+    phase: 'p6',
+    qa: qa.filter(Boolean),
+    gate: g,
+    note: 'Green automation is insufficient per the plan: the maintainer must inspect the staging screenshots in website/test/visual/staging/ and explicitly approve before Phase 7.',
+  }
+}
+
+// ---------------------------------------------------------------- p7
+if (ph === 'p7') {
+  if (!A || !A.prodUrl) return { error: 'Pass args.prodUrl. Run this AFTER the maintainer performs the Cloudflare origin switch — the switch itself is a human action, not this workflow.' }
+  const P = A.prodUrl
+  const smoke = await parallel([
+    () => agent(`${CTX}\nSmoke ${P}: all six routes + trailing slashes, all .md URLs, llm.txt, robots, sitemap, all three APIs, video HEAD/Range/playback via agent-browser, badges. Kill Chrome for Testing helpers afterwards. pass=false triggers the plan's rollback rule.`, { label: 'smoke:full', phase: 'P7 Cutover Smoke', model: 'sonnet', effort: 'high', schema: CHECK }),
+    () => agent(`${CTX}\nScreenshot ${P} all six routes both viewports with agent-browser and compare to the approved staging baselines in website/test/visual/staging/. Kill Chrome for Testing helpers afterwards. pass=false on visual regression.`, { label: 'smoke:visual', phase: 'P7 Cutover Smoke', model: 'sonnet', effort: 'medium', schema: CHECK }),
+    () => agent(`${CTX}\nCheck origin health signals available from here: response times across 20 sequential requests per route, error rates, and (if args-provided SSH host is reachable) container logs, CPU, and memory on the origin. Read-only.`, { label: 'smoke:health', phase: 'P7 Cutover Smoke', model: 'sonnet', effort: 'low', schema: CHECK }),
+  ])
+  const failed = smoke.filter(Boolean).some(c => !c.pass)
+  if (failed) log('SMOKE FAILURE: per the plan, restore the previous Cloudflare Pages origin FIRST, investigate second.')
+  const g = await gate('Phase 7', smoke.filter(Boolean))
+  return { phase: 'p7', smoke: smoke.filter(Boolean), gate: g, rollbackRequired: failed }
+}
+
+// ---------------------------------------------------------------- p8
+if (ph === 'p8') {
+  if (!A || !A.worktree) return { error: 'Pass args.worktree. Run only after the 7-day observation window.' }
+  const cleanup = await agent(
+    `${CTX}\nPhase 8 cleanup in worktree ${A.worktree}: remove the old Astro website/ (Astro, @astrojs/cloudflare, Tailwind, React, obsolete build config), promote website-shibumi/ to website/, run bun audit, and confirm zero website advisories. Do NOT touch Cloudflare Pages deployment hooks — that is the maintainer's call. Commit as bitbonsai.`,
+    { label: 'cleanup', phase: 'P8 Cleanup', model: 'sonnet', effort: 'medium' }
+  )
+  const [docs, triage, upstream] = await parallel([
+    () => agent(`${CTX}\nUpdate website/AGENTS.md, root command docs, README contributor guidance, and deployment documentation to describe the Bun/Hono/Podman setup. Commit as bitbonsai.`, { label: 'docs', phase: 'P8 Cleanup', model: 'sonnet', effort: 'medium' }),
+    () => agent(`${CTX}\nUpdate ${REPO}/.triage/ state: note the migration, and list which website dependency alerts GitHub now shows resolved (gh api, read-only) — close them in the state file only if GitHub confirms. Report remaining alerts.`, { label: 'triage-state', phase: 'P8 Cleanup', model: 'sonnet', effort: 'low', schema: CHECK }),
+    () => agent(`${CTX}\nWrite ${REPO}/.plans/shibumi-upstream-notes.md: which TSX partials, Alpine module patterns, CSS-scoping conventions, and visual-test patterns from this migration are worth separate upstream Shibumi PRs, with file references. MCPVault must not depend on those landing.`, { label: 'upstream-notes', phase: 'P8 Cleanup', effort: 'medium' }),
+  ])
+  const g = await gate('Phase 8', { cleanup, docs, triage, upstream })
+  return { phase: 'p8', cleanup, docs, triage, upstream, gate: g }
+}
+
+return { error: `Unknown phase "${ph}". Use p0..p8.` }

--- a/.plans/INDEX.md
+++ b/.plans/INDEX.md
@@ -1,6 +1,7 @@
 # Plans
 
 ## Active
+- [ ] [Shibumi website migration](shibumi-website-migration.md): p0–p5 DONE, `shibumi` branch pushed (302 tests green); next: shibumi-server install on Hetzner + staging.mcpvault.org, then p6 staging QA; deploy = shibumi-server in-situ builds behind Caddy
 - [ ] MCP SDK v2 migration on `feat/mcp-sdk-v2`: dual-era stdio works; rebase onto `main`, then replace session HTTP with stateless v2 handlers
 - [ ] Contributor PRs #146, #163, #164, #173, #174, #175 waiting on requested changes
 - [ ] Issue follow-ups #49, #165, #167, #170 waiting on testers/contributors

--- a/.plans/shibumi-website-migration.md
+++ b/.plans/shibumi-website-migration.md
@@ -1,0 +1,408 @@
+# MCPVault website migration to Shibumi Stack
+
+## Status
+
+p0–p5 done; `shibumi` branch pushed to origin 2026-08-10 (CI workflow `.github/workflows/website-shibumi.yml` dropped in `aa3350f` — maintainer call, deploy is in-situ so Actions adds nothing). Next: Hetzner host + staging hostname, then host setup and p6. Do not change production hosting until the staging and visual-regression gates below pass and the maintainer explicitly approves cutover.
+
+## Why
+
+The current website is restored on Astro 5 + `@astrojs/cloudflare` 12 after the Astro 7 / adapter 14 upgrade produced Workers-style artifacts that Cloudflare Pages accepted but served as 404s. The rollback restored production but reopened nine website dependency advisories.
+
+The target is a small, portable Shibumi-style application running on the existing Hetzner server:
+
+- Bun runtime and package manager
+- Hono routes and server-rendered TSX
+- Alpine for browser state
+- Zod at request boundaries
+- plain CSS with explicit component roots
+- native cross-document View Transitions
+- rootless Podman behind the existing Cloudflare proxy
+
+No database is needed. Do not add Drizzle or persistent storage.
+
+## Approved deviations from production
+
+Deliberate, maintainer-approved differences the visual/parity gates must not flag:
+
+- npm downloads badge anchor (Hero) and the footer npm icon link point at `@bitbonsai/mcpvault` (production links both to the nonexistent unscoped `mcpvault` package).
+- Newsletter "Stay in the loop" eyebrow drops the decorative dash (`.eyebrow-line`) present in `NewsletterSignup.astro` (commit `16489cd`).
+- `sitemap.xml` serves real XML (production serves an SPA HTML fallback).
+- `sitemap-0.xml` 301s to `/sitemap.xml` instead of reproducing production's broken 200 `text/html` SPA fallback (Phase 2 review, headers-baseline finding); the two URLs no longer serve duplicate bodies.
+- Footer gains a "Built with Shibumi Stack" credit linking to https://shibumi.site (maintainer request 2026-08-10, commit `582c67c`).
+- Nav is glass: background opacity 0.7 + 16px backdrop blur, links nowrap/ellipsis (maintainer requests 2026-08-10, commits `4ca8324`, `f927416`; production nav is 0.95 opaque, no blur).
+- The install-page Terminal is demo-purpose only (maintainer decision 2026-08-10): implementation deliberately simplified versus the 48k `Terminal.astro`; visual result stays close but is not held to pixel parity, and over-engineered internals (typing animations, complex state) may be dropped.
+
+## Non-goals
+
+- No visual redesign during migration. Preserve the current information architecture, copy, responsive behavior, and interaction design.
+- No MCP server/package behavior changes or npm version bump.
+- No Cloudflare Workers runtime.
+- No dependency on an unpublished Shibumi package. Reuse and dogfood the public `shibumistack.dev` source patterns; upstream reusable improvements separately.
+- Do not disable Cloudflare Pages until the Hetzner deployment has been stable and rollback-tested.
+
+## Target architecture
+
+```text
+Cloudflare proxy
+      |
+Hetzner origin TLS / existing reverse proxy
+      |
+rootless Podman container (Bun + Hono)
+      |-- server-rendered TSX pages
+      |-- static assets and Markdown
+      |-- GET  /api/downloads.json
+      |-- POST /api/subscribe
+      `-- GET  /api/unsubscribe
+```
+
+The server is stateless. Runtime configuration is limited to `RESEND_API_KEY`, `RESEND_AUDIENCE_ID`, host/port, and optional trusted-proxy settings.
+
+## Proposed website structure
+
+```text
+website/
+  Containerfile
+  compose.yaml or deploy/quadlet/
+  package.json
+  bun.lock
+  server.ts
+  src/
+    app.tsx
+    layouts/
+      Layout.tsx
+    components/
+      *.tsx
+    pages/
+      Home.tsx
+      Install.tsx
+      Features.tsx
+      Demo.tsx
+      HowItWorks.tsx
+      Skill.tsx
+    routes/
+      downloads.ts
+      subscribe.ts
+      unsubscribe.ts
+    content/
+      *.md
+    client/
+      alpine.ts
+    styles/
+      shared.css
+      home.css
+      install.css
+      features.css
+      demo.css
+      how-it-works.css
+      skill.css
+  public/
+    llm.txt
+    media and icons
+  test/
+    routes/
+    integration/
+    visual/
+```
+
+## Rendering and browser decisions
+
+### TSX and partials
+
+Use Hono JSX functional components and a shared `Layout`. Components are ordinary server-rendered `.tsx` functions, not React components. Use Hono's JSX renderer and escaping defaults; audit every use of raw HTML.
+
+Read the package version from the root `package.json` once at startup. Preserve the current URLs, canonical metadata, Open Graph data, structured data, and Markdown endpoints.
+
+### Markdown
+
+Reuse the content-discovery and content-negotiation ideas from public `shibumistack.dev`:
+
+- HTML is the browser default.
+- Existing `website/public/*.md` URLs and `llm.txt` remain stable.
+- `Accept: text/markdown` may return the matching Markdown source where available.
+- Rich TSX pages and Markdown representations remain synchronized until a later project proves a single canonical source can represent both without losing browser content.
+
+### Alpine
+
+Use Alpine only where state is required:
+
+- mobile navigation
+- theme toggle
+- interactive demo and response rendering
+- terminal controls/copy behavior
+- newsletter submission state
+
+Keep state/data in named modules rather than large inline `x-data` expressions. Bundle or vendor Alpine locally; do not introduce a runtime CDN dependency.
+
+Use the `@alpinejs/csp` build so the CSP ships without `'unsafe-eval'`. The standard Alpine build evaluates attribute strings via the `Function()` constructor, which a strict CSP blocks. The CSP build restricts attributes to naming registered `Alpine.data()` modules and their methods, which matches the named-modules rule above. If the interactive demo proves impossible under the restricted syntax, fall back to the standard build plus `'unsafe-eval'` and document the trade-off explicitly.
+
+### View Transitions
+
+Use native cross-document View Transitions (`@view-transition { navigation: auto; }`) with normal multi-page navigation and graceful fallback. Do not recreate Astro's client router or add a custom SPA router unless a measured UX regression proves it necessary.
+
+### Pragmatic CSS scoping
+
+Use plain cached stylesheets, not CSS Modules or CSS-in-JS:
+
+- global tokens/reset/layout in `shared.css`
+- one stylesheet per route
+- every component has a unique root such as `data-component="hero"` or `.c-hero`
+- every component selector is rooted under that namespace
+- page-only selectors are rooted under a page identifier
+- preserve reduced-motion, focus, high-contrast, and mobile behavior
+
+Example:
+
+```css
+[data-component="hero"] { ... }
+[data-component="hero"] .title { ... }
+```
+
+Convert Tailwind utilities and Astro scoped styles deliberately; do not ship both old and new styling systems.
+
+### Syntax highlighting and icons
+
+Replace React-only highlighting with server-side Shiki output cached at startup, or preserve pre-rendered highlighted markup where static. Replace `lucide-react` with an audited inline SVG helper or a runtime-neutral Lucide package. Preserve accessible labels and `aria-hidden` behavior.
+
+## Dynamic route parity
+
+### `GET /api/downloads.json`
+
+- Preserve the Shields endpoint schema exactly.
+- Fetch totals for both npm package names.
+- Add explicit upstream timeouts and a bounded in-memory cache.
+- Preserve the current cache headers.
+- Return a last-known value or controlled error if npm is unavailable; never hang the badge request.
+
+### `POST /api/subscribe`
+
+- Parse JSON and form-urlencoded bodies.
+- Validate and normalize email with Zod.
+- Inject the Resend client in tests.
+- Check every Resend `{ error }` result.
+- Send the welcome email reliably; do not use an untracked fire-and-forget promise.
+- Use an idempotency key to prevent duplicate welcome emails on retries.
+- Keep secrets outside the image.
+
+### `GET /api/unsubscribe`
+
+- Preserve current behavior during parity migration.
+- Add tests for missing email, normalization, Resend errors, and successful removal.
+- Track signed unsubscribe tokens as a separate security follow-up rather than silently changing existing links during migration.
+
+## Migration phases
+
+### Phase 0 — establish safety and baseline
+
+1. Merge the visual-regression guardrail in PR #190.
+2. Confirm current production pages, video, posters, badges, and all three APIs are healthy.
+3. Capture deterministic baseline screenshots for all six routes at desktop and mobile sizes; store them in the repo under `website/test/visual/baseline/`.
+4. Record current Lighthouse/accessibility results, and save essential response headers as machine-readable `website/test/baseline/headers-baseline.json` so later phases can diff automatically instead of eyeballing.
+5. Audit the Hetzner host without changing it:
+   - architecture and OS
+   - current reverse proxy and TLS ownership
+   - rootless Podman/systemd conventions
+   - available ports, firewall, disk, and memory
+   - Cloudflare origin configuration
+6. Choose a staging hostname and rollback DNS target.
+
+Gate: no migration work starts without usable visual baselines and a known production rollback.
+
+### Phase 1 — build a parallel Shibumi application
+
+1. Develop in a dedicated worktree/branch.
+2. Create the Hono/Bun/TSX skeleton alongside the live Astro website so Cloudflare Pages remains untouched.
+3. Add `/healthz`, static serving, error handling, security headers, request logging, and graceful shutdown.
+4. Add route tests using `app.request()` before porting pages.
+5. Commit a separate Bun lockfile and make CI use `bun install --frozen-lockfile`.
+6. Build a dedicated video route on `Bun.file(path).slice(start, end)` handling `HEAD`, full `GET`, and `Range` requests with correct `206 Partial Content`, `Content-Range`, and `Accept-Ranges` headers, plus tests. Decided upfront: do not rely on Hono's `serveStatic` for video — its Bun Range support has been incomplete, and Safari refuses to play video without Range support.
+
+Gate: skeleton builds, tests, audits, starts in a container, and shuts down cleanly.
+
+### Phase 2 — migrate server-rendered pages
+
+Port in reviewable groups while preserving URLs and semantics:
+
+1. Shared shell: `Layout`, navigation, footer, theme, metadata, plus explicit `sitemap.xml` and `robots.txt` routes (Astro's sitemap integration goes away, so these must be built, not just checked in QA).
+2. Home: Hero, FeatureGrid/Card, CodeExample/CodeBlock, FAQ, UpdateCallout, SpecPreviewCallout, NewsletterSignup.
+3. Features: ComparisonTable and associated content.
+4. Install: Terminal and copy/tab behavior.
+5. How It Works.
+6. Skill: SkillsContent.
+7. Demo shell and response examples, leaving interactivity for Phase 3.
+
+For every group:
+
+- port TSX markup
+- port scoped/page CSS
+- preserve Markdown counterpart
+- add route assertions
+- capture local desktop/mobile screenshots
+- compare with baseline before continuing
+
+Gate: all direct routes render without JavaScript and match current content and responsive layout.
+
+### Phase 3 — replace browser interactivity
+
+1. Port `InteractiveDemo.tsx` and `ResponseRenderer.tsx` to Alpine modules.
+2. Port navigation, theme, terminal, copy, and newsletter behavior.
+3. Add cross-document View Transitions and reduced-motion fallback.
+4. Verify browser back/forward, deep links, keyboard operation, focus restoration, and no-JS fallback.
+5. Remove React, Astro client directives, and React-only dependencies only after parity tests pass.
+
+Gate: functional browser tests pass at desktop and mobile widths with no console errors or hydration/runtime warnings.
+
+### Phase 4 — migrate APIs and static assets
+
+1. Port and test the three Hono API routes.
+2. Replicate the Cloudflare trailing-slash and route-redirect behavior from PRs #187/#188 as Hono middleware with tests, so redirects do not depend on Cloudflare rules surviving the origin switch.
+3. Preserve all public Markdown and LLM files.
+4. Preserve media filenames and caching semantics.
+5. Test normal and byte-range video requests through the Phase 1 dedicated video route; playback must work in a real browser.
+6. Test every external badge source and the local downloads badge payload.
+7. Remove Astro, `@astrojs/cloudflare`, Tailwind, React, and obsolete build configuration.
+8. Run Bun audit and Dependabot review; target zero open website advisories.
+
+Gate: container serves every page, asset, Markdown file, and API with expected status, content type, cache headers, and body.
+
+### Phase 5 — container and staging deployment
+
+1. Build a minimal, pinned Bun container image.
+2. Run rootless and non-root with:
+   - read-only root filesystem where practical
+   - dropped capabilities
+   - `no-new-privileges`
+   - 512 MB memory limit
+   - conservative CPU limit
+   - health check on `/healthz`
+   - restart through systemd/Quadlet or the host's established Podman convention
+3. Publish immutable commit-SHA images to GHCR.
+4. Deploy to the staging hostname behind Cloudflare with Full (strict) origin TLS.
+5. Supply Resend secrets via a mode-0600 environment file or systemd credentials.
+6. Verify logs, restart after reboot, health failures, and rollback to the previous image.
+
+Gate: staging survives restart/reboot tests and has no direct public origin exposure beyond the intended proxy path.
+
+### Phase 6 — mandatory deployed-preview QA
+
+Run against the actual staging hostname, not localhost:
+
+- Playwright screenshot comparisons for all six routes at desktop and mobile sizes
+- maintainer visual inspection and explicit approval
+- direct and trailing-slash route checks
+- video poster, metadata, byte-range request, and actual playback
+- all static images, fonts, icons, and downloadable Markdown
+- GitHub/npm/support badges and `/api/downloads.json`
+- newsletter validation/error path; use a controlled Resend test configuration
+- unsubscribe validation/error path
+- keyboard navigation, visible focus, reduced motion, and theme persistence
+- browser console/network errors
+- page metadata, canonical URLs, robots, sitemap, and structured data
+- Cloudflare cache behavior and origin headers
+
+Make screenshots deterministic: disable animations, freeze video at its poster/first frame, and mask or stub counters that legitimately change. Store approved baselines and fail CI on unexpected pixel differences.
+
+Gate: green automated tests are insufficient. The maintainer must inspect deployed screenshots and approve the staging site.
+
+### Phase 7 — cutover and observation
+
+1. Build and deploy an immutable production image from the approved commit.
+2. Confirm production health through the Hetzner origin before DNS/proxy changes.
+3. Switch the Cloudflare origin to Hetzner.
+4. Run the full route/asset/API/browser smoke suite against `mcpvault.org`.
+5. Monitor logs, health, errors, CPU, memory, and response times closely.
+6. Keep the previous Cloudflare Pages production deployment available for at least seven days.
+7. Do not remove rollback DNS/configuration until the observation window ends.
+
+Rollback immediately if pages, media, APIs, TLS, or visual checks regress: restore the previous Cloudflare Pages origin first, investigate second.
+
+### Phase 8 — cleanup and upstream learning
+
+1. Remove the parallel Astro website only after the observation window.
+2. Disable obsolete Cloudflare Pages production deployment hooks only after rollback is no longer needed.
+3. Update `website/AGENTS.md`, root commands, README contributor guidance, and deployment documentation.
+4. Update `.triage/` state and close website dependency alerts only after GitHub confirms them resolved.
+5. Port generally useful TSX partials, Alpine, CSS-scoping, and visual-test patterns back to Shibumi in separate Shibumi PRs. MCPVault must not depend on those upstream changes landing.
+
+## Test matrix
+
+### Unit/route
+
+- every HTML and Markdown route
+- 404 and unsupported method handling
+- content negotiation
+- package-version injection
+- safe escaping/raw HTML boundaries
+- download aggregation success, timeout, partial upstream failure, and cache
+- subscription body formats, validation, normalization, Resend errors, idempotency
+- unsubscribe missing/success/error paths
+
+### Integration/container
+
+- clean image build from lockfile
+- non-root process and read-only filesystem
+- health and graceful shutdown
+- root/static/index routes
+- content types and cache headers
+- video `HEAD`, full `GET`, and `Range` request
+- no secrets in image layers or logs
+- restart and rollback
+
+### Browser/visual
+
+- Chromium desktop and mobile baselines for `/`, `/install`, `/features`, `/demo`, `/how-it-works`, `/skill`
+- navigation and browser history
+- Alpine interactions
+- theme persistence
+- video playback
+- newsletter UI states
+- reduced motion and keyboard focus
+- zero console/page errors
+
+### Security
+
+- `bun audit` clean
+- Dependabot clean for website manifest
+- CSP ships without `'unsafe-eval'` (Alpine CSP build); headers reviewed for video, Shields, and Resend
+- CSRF decision documented for subscription endpoint
+- request size limits on newsletter endpoints; primary rate limiting as a Cloudflare WAF rule on `/api/subscribe` (the container is stateless, so in-memory app limits reset on every restart and are best-effort only)
+- deploy webhook verifies GitHub HMAC signature with constant-time comparison, validates image tags as commit SHAs, and rejects everything else
+- origin restricted appropriately behind Cloudflare
+- container runs without root or unnecessary capabilities
+
+## Acceptance criteria
+
+- Production design/content parity approved from deployed screenshots.
+- All six browser routes, Markdown routes, video, badges, and three APIs work on the staging and production domains.
+- Website dependency audit has no known advisories.
+- No Astro, React, Tailwind, or Cloudflare runtime adapter remains.
+- Container is stateless, non-root, resource-limited, health-checked, restart-safe, and rollback-tested.
+- Cloudflare is only DNS/proxy/cache; no Worker is required.
+- Existing Cloudflare Pages deployment remains a tested rollback during the observation window.
+- Root MCP package, npm version, and release process remain unchanged.
+
+## Deploy: shibumi-server, in-situ builds (decided 2026-08-10)
+
+Deployment uses the maintainer's own `shibumi-server` (~/bit/shibumi-server, dogfooding it as its first production install) instead of a registry pipeline. No GHCR, no image publishing from CI; the CI that remains is test-only.
+
+Flow: signed GitHub **push** webhook → Caddy routes `/hooks/github/mcpvault-web` to shibumi-server on loopback → it verifies HMAC/repository/branch/SHA (replay-cached delivery IDs), fetches the exact commit, builds the image in situ with rootless podman compose, health-checks the new container, and keeps the active image plus two rollback images. Resource guards refuse builds when host memory/disk are low; builds are killed on timeout.
+
+```text
+GitHub push webhook
+      |
+Cloudflare → Caddy (host HTTPS)
+      |-- /hooks/github/mcpvault-web → shibumi-server (127.0.0.1)
+      `-- everything else            → mcpvault-web container (127.0.0.1:9100)
+```
+
+- App ships `website-shibumi/compose.yaml` carrying the same hardening as the container gate verified (read-only, cap-drop ALL, no-new-privileges, 512MB/0.5 CPU, healthcheck).
+- Resend secrets + webhook secret live in mode-0600 env files on the host, never in the repo or image.
+- Reverse proxy open decision resolved: **Caddy** fronts the host behind Cloudflare.
+- Cost accepted: ~30-90s CPU burst per deploy on the host; rollback depth = retained images (2).
+
+## Open decisions before implementation
+
+- Reverse proxy: resolved — Caddy (maintainer decision 2026-08-10).
+- Which staging hostname should be used?
+- Deploy mechanism: resolved — shibumi-server with in-situ podman builds per the "Deploy" section above (GHCR pipeline dropped 2026-08-10).
+- Should HTML/Markdown content remain manually dual-maintained initially, or can a narrow subset safely use Markdown as canonical source? Note: Bun ships native `Bun.markdown` (`.html()/.ansi()/.render()/.react()`, verified on 1.3.14), so canonical-markdown rendering needs zero added dependencies and `marked` can be dropped.
+- Should reusable Shibumi TSX/Alpine work be developed upstream first or extracted after MCPVault proves it (webhook receiver is a candidate for upstreaming into shibumi-server)?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,3 +145,9 @@ When modifying file operations:
 - MCP SDK v2 uses split `@modelcontextprotocol/server`, `/client`, `/core`, `/node` packages. `@modelcontextprotocol/sdk@latest` remains v1.x.
 - Version bump updates website nav/Hero automatically only. Manually sync `website/src/components/UpdateCallout.astro`, `website/public/index.md`, and `CHANGELOG.md`.
 - Production npm publishing is triggered by a GitHub Release and runs with provenance. Follow `RELEASING.md`; do not manually run `npm publish` for normal production releases, and do not backfill a release for an npm version that already exists.
+- website-shibumi (shibumi branch) Hono JSX: escapes string children even inside `<script>` — JSON-LD/inline scripts need `raw()`; HTML entities in JSX text double-escape, use literal Unicode chars.
+- Bun TSX parser rejects dotted attribute names: Alpine modifiers need spread form `{...{"x-on:click.outside": "close()"}}`.
+- Hono `c.header()` in middleware after `next()` rebuilds Response from `.body` — drops `Bun.file().slice()` Range bodies (video 206 becomes full file). Mutate `c.res.headers.set()` directly.
+- hono serveStatic on Bun: incomplete Range support — video served by dedicated route on `Bun.file().slice()` (src/routes/video.ts), never serveStatic.
+- website-shibumi container builds from REPO ROOT context (`-f website-shibumi/Containerfile .`): root package.json must be copied to `/package.json` or server exits 1 at import (version badge reads it).
+- CSS: `animation-fill-mode: forwards` keeps finished animation attached forever and kills descendant `backdrop-filter` even with final `transform: none`; detach via `.fade-in-done { animation: none }` on animationend.


### PR DESCRIPTION
Migration collateral for the website-shibumi work on the `shibumi` branch:

- `.plans/`: migration plan (source of truth for phases p0-p8) and INDEX entry
- `AGENTS.md`: six gotchas learned building website-shibumi (Hono JSX escaping, Bun TSX attributes, Range handling, container build context, CSS fill-mode)
- `.claude/workflows/shibumi-migration.js`: phase orchestration script

Docs only, no code paths touched.