### PR TITLE
docs(website): point semantic-search FAQ at companion MCP servers

### DIFF
--- a/website/public/features.md
+++ b/website/public/features.md
@@ -64,7 +64,7 @@ Yes. Configure multiple MCP server entries, one per vault path.
 Read/write tools support `.md`, `.markdown`, `.txt`, `.base`, and `.canvas` files. `list_directory` may show other filenames (like `.png` or `.pdf`), but non-note files are not read as notes.
 
 ### Is search semantic?
-No. Search is lexical full-text matching with BM25 ranking, not embedding/vector semantic retrieval.
+No. Search is lexical full-text matching with BM25 ranking, not embedding/vector semantic retrieval. For semantic search, pair MCPVault with a dedicated vector-search MCP server such as Qdrant's [mcp-server-qdrant](https://github.com/qdrant/mcp-server-qdrant) or Chroma's [chroma-mcp](https://github.com/chroma-core/chroma-mcp): the companion server owns embeddings and its index while MCPVault stays deterministic and local.
 
 ### What if the AI makes a mistake?
 Use backups or version control. Deletions require explicit path confirmation and all operations stay inside your configured vault.

--- a/website/src/components/FAQ.astro
+++ b/website/src/components/FAQ.astro
@@ -18,7 +18,7 @@ const faqItems = [
   },
   {
     q: 'Is search semantic?',
-    a: 'Search is lexical full-text search with multi-word matching and BM25 relevance ranking. It does not use embeddings or vector indexes.'
+    a: 'Search is lexical full-text search with multi-word matching and BM25 relevance ranking. It does not use embeddings or vector indexes. For semantic search, pair MCPVault with a dedicated vector-search MCP server such as Qdrant\'s mcp-server-qdrant or Chroma\'s chroma-mcp: the companion server owns the embeddings index while MCPVault stays deterministic and local.'
   },
   {
     q: 'What if the AI makes a mistake?',


### PR DESCRIPTION
Follow-up to Discussion #7: the FAQ said to pair MCPVault with a dedicated semantic-search MCP server but never named any. The "Is search semantic?" answer now points at Qdrant's mcp-server-qdrant and Chroma's chroma-mcp, in both the HTML FAQ and the markdown mirror (dual-content rule).

Same change applied to the shibumi branch (website-shibumi) so it survives the migration.