### PR TITLE
Configure Shibumi production deployment

### DIFF
--- a/shibumi-server.json
+++ b/shibumi-server.json
@@ -11,5 +11,5 @@
   "webhookUrl": "https://mcpvault.org/hooks/github/mcpvault-org",
   "service": "web",
   "healthPath": "/healthz",
-  "cutoverRequired": true
+  "cutoverRequired": false
 }


### PR DESCRIPTION
## Summary

Finalize Shibumi production registration after setup on Alpha.

- mark `mcpvault.org` Caddy registration active
- deploy `main` through production Shibumi app after merge

## Verification

- root test suite: 277 passed
- Alpha production app registered at `127.0.0.1:9103`
- public DNS remains on Cloudflare Pages until production loopback health passes
