### PR TITLE
docs: 0.16.0 release notes and MCP v2 shipped copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-08-17
+
+### Changed
+- Migrated to the official MCP TypeScript SDK v2 (`@modelcontextprotocol/server` 2.0.0, spec 2026-07-28).
+- The stdio server is now dual-era: legacy and 2026-07-28 clients are served from the same process, selected per connection. No latency change for existing clients (see https://mcpvault.org/benchmarks).
+
+### Added
+- Protocol matrix tests covering both protocol eras.
+- `benchmarks/` scripts comparing MCP v1 and MCP v2 latency.
+
 ## [0.15.0] - 2026-08-09
 
 ### Added

--- a/MCP_SDK_V2.md
+++ b/MCP_SDK_V2.md
@@ -1,21 +1,8 @@
-# MCP SDK v2 preview
+# MCP v2
 
-> Experimental branch. Not published to npm.
+MCPVault runs on the official TypeScript SDK v2 (`@modelcontextprotocol/server`)
+and the MCP 2026-07-28 specification since 0.16.0. The stdio server is dual-era:
+legacy and 2026-07-28 clients are both served from one process, selected per
+connection during the opening exchange.
 
-This branch tracks MCPVault's migration to the MCP 2026-07-28 specification and the TypeScript SDK v2.
-
-## Working now
-
-- TypeScript SDK v2 package split
-- Dual-era stdio server: legacy MCP and 2026-07-28
-- Protocol matrix tests for both eras
-- Existing MCPVault test suite and security audit
-
-## Before release
-
-- Let the SDK v2 patch line and client ecosystem settle
-- Rebase current MCPVault feature work
-- Replace the experimental HTTP session layer with the stateless v2 handler
-- Verify legacy and modern HTTP clients through the MCP Inspector
-
-Production users should continue installing `@bitbonsai/mcpvault@latest`.
+Benchmarks and details: https://mcpvault.org/benchmarks

--- a/website/public/index.md
+++ b/website/public/index.md
@@ -11,7 +11,7 @@ This MCP server lets Claude, ChatGPT+, and other assistants access your vault. L
 
 ## Announcement
 
-- **The [latest MCP spec](https://modelcontextprotocol.io/specification/latest) is out.** We’re getting MCPVault ready for it. [View feat/mcp-sdk-v2](https://github.com/bitbonsai/mcpvault/tree/feat/mcp-sdk-v2).
+- **MCPVault runs on [MCP v2](https://modelcontextprotocol.io/specification/latest), the latest MCP spec.** Same speed for every client, old and new. [See the benchmarks](https://mcpvault.org/benchmarks.md).
 - **JUST LAUNCHED - Obsidian Skill:** Smart routing across MCP, Obsidian app context, and Git CLI sync is now live, with preflight checks, targeted setup questions, and safe sync defaults. [See skill flows](/skill.md)
 
 ## Recent Updates

--- a/website/src/components/SpecPreviewCallout.astro
+++ b/website/src/components/SpecPreviewCallout.astro
@@ -16,10 +16,10 @@ const specUrl = 'https://modelcontextprotocol.io/specification/latest';
 
           <p class="text-sm leading-relaxed text-muted-foreground">
             <span class="font-semibold text-foreground">
-              The <a href={specUrl} target="_blank" rel="noopener noreferrer" class="spec-link">latest MCP spec</a> is out.
+              MCPVault runs on <a href={specUrl} target="_blank" rel="noopener noreferrer" class="spec-link">MCP v2</a>, the latest spec.
             </span>
-            <span class="sm:hidden"> We’re getting ready for it.</span>
-            <span class="hidden sm:inline"> We’re getting MCPVault ready for it.</span>
+            <span class="sm:hidden"> Same speed, every client.</span>
+            <span class="hidden sm:inline"> Same speed for every client, old and new.</span>
           </p>
         </div>
 


### PR DESCRIPTION
Changelog for 0.16.0, MCP_SDK_V2.md updated from preview to shipped, homepage banner + markdown mirror updated to present tense.