### PR TITLE
docs(website): 0.16.0 release callout

### DIFF
--- a/website/public/index.md
+++ b/website/public/index.md
@@ -16,6 +16,7 @@ This MCP server lets Claude, ChatGPT+, and other assistants access your vault. L
 
 ## Recent Updates
 
+- **v0.16.0 (August 2026):** Migrated to **MCP v2**, the official SDK for the 2026-07-28 spec. One process serves both protocol generations at the same speed ([benchmarks](https://mcpvault.org/benchmarks.md)).
 - **v0.15.0 (August 2026):** Added `--read-only` mode, which exposes read tools only and rejects all vault mutations. ([#112](https://github.com/bitbonsai/mcpvault/issues/112), thanks @vdhome-dev)
 - **v0.14.1 (August 2026):** Security: dotfiles and hidden directories are now denied at any vault depth, closing an extension-filter bypass. ([#115](https://github.com/bitbonsai/mcpvault/pull/115), thanks @sadegh)
 - **v0.14.0 (August 2026):** Added `get_note_outline` and `read_note_lines` for navigating and reading targeted sections of large notes without loading the full file. ([#146](https://github.com/bitbonsai/mcpvault/pull/146), thanks @kartik7704)

--- a/website/src/components/UpdateCallout.astro
+++ b/website/src/components/UpdateCallout.astro
@@ -16,7 +16,7 @@ import { Rocket } from 'lucide-react';
             <h3 class="text-lg font-semibold text-foreground flex items-center gap-2">
               Recent Updates
               <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-accent/20 text-accent border border-accent/30">
-                v0.15.0
+                v0.16.0
               </span>
             </h3>
             <button
@@ -36,13 +36,17 @@ import { Rocket } from 'lucide-react';
           </div>
           <div class="mb-4">
             <p class="text-muted-foreground leading-relaxed">
-              <span class="font-medium text-foreground">v0.15.0 (August 2026):</span> Added <code>--read-only</code> mode, which exposes read tools only and rejects all vault mutations
-              (<a href="https://github.com/bitbonsai/mcpvault/issues/112" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">#112</a>, thanks @vdhome-dev)
+              <span class="font-medium text-foreground">v0.16.0 (August 2026):</span> Migrated to <strong class="font-medium text-foreground">MCP v2</strong>, the official SDK for the 2026-07-28 spec. One process serves both protocol generations at the same speed
+              (<a href="https://mcpvault.org/benchmarks" class="text-accent hover:text-accent-2 transition-colors">benchmarks</a>)
             </p>
           </div>
 
           <div id="older-updates" class="older-updates is-collapsed" data-updates-panel>
             <ul class="text-muted-foreground space-y-2">
+              <li>
+                <span class="font-medium text-foreground">v0.15.0 (August 2026):</span> Added <code>--read-only</code> mode, which exposes read tools only and rejects all vault mutations
+                (<a href="https://github.com/bitbonsai/mcpvault/issues/112" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">#112</a>, thanks @vdhome-dev)
+              </li>
               <li>
                 <span class="font-medium text-foreground">v0.14.1 (August 2026):</span> Security: dotfiles and hidden directories are now denied at any vault depth, closing an extension-filter bypass
                 (<a href="https://github.com/bitbonsai/mcpvault/pull/115" target="_blank" rel="noopener noreferrer" class="text-accent hover:text-accent-2 transition-colors">#115</a>, thanks @sadegh)


### PR DESCRIPTION
Updates the homepage Recent Updates callout and index.md mirror: v0.16.0 / MCP v2 as latest, 0.15.0 moved into history.