### PR TITLE
Port MCP v2 benchmarks page to the live site (website-shibumi)

### DIFF
--- a/website-shibumi/public/benchmarks.md
+++ b/website-shibumi/public/benchmarks.md
@@ -1,0 +1,43 @@
+# MCP v2 Benchmarks
+
+**TL;DR:** benchmarks of MCPVault on **MCP v2**: ~107 ms to connect and identical per-request speed, whether the app talks the old protocol or the new one. Below: the numbers, why we moved, what stateless HTTP opens up, and answers for skeptics.
+
+MCPVault runs on the MCP 2026-07-28 specification via the new official SDK, which we call **MCP v2**. It serves both protocol generations from a single process: each client gets an answer in whichever version it speaks. Existing setups keep working unchanged.
+
+## Results
+
+Three pairings, one real vault (381 notes, 84 folders, 3.2 MB), stdio, read-only. Measured 2026-08-17 on macOS, Node 26, SDK 1.30.0 vs 2.0.0. Medians in ms.
+
+| metric | MCPVault today | MCP v2, today's apps | MCP v2, new apps |
+|---|---|---|---|
+| cold start (n=8) | 107.3 | 109.8 | 105.8 |
+| tools/list (n=50) | 0.15 | 0.14 | 0.17 |
+| get_vault_stats (n=50) | 12.13 | 11.4 | 11.66 |
+| read_note (n=50) | 0.46 | 0.43 | 0.45 |
+| list_directory (n=50) | 0.45 | 0.43 | 0.46 |
+| search_notes (n=20) | 85.53 | 84.33 | 85.62 |
+
+All three pairings tie within run-to-run noise. The **MCP v2** build costs existing clients nothing.
+
+## Why should we move
+
+- **Every client, one server.** The **MCP v2** build detects each client's protocol during the opening exchange.
+- **The maintained SDK line.** New MCP features and security patches land in the **MCP v2** packages first.
+- **Richer tool definitions ahead.** The new spec supports full JSON Schema 2020-12 for tool inputs.
+
+## HTTP possibility
+
+The 2026-07-28 spec makes the HTTP transport stateless, so an MCP server can sit behind any ordinary load balancer. For MCPVault that means a future opt-in HTTP package built on this **MCP v2** core, while the default stays local-first stdio. Tracked in [issue #49](https://github.com/bitbonsai/mcpvault/issues/49).
+
+## For the skeptics
+
+- **Sub-millisecond tool calls?** stdio on the same machine: no network, file already in the OS cache. Isolates server processing, the only part the SDK swap could change.
+- **Tiny samples (n=8 cold, n=20 search).** True. Enough to compare medians of a quiet local process, and why the claim is a tie, never a speedup. p95 in the table.
+- **MCP v2 wins some rows.** Noise. Those differences flip between runs. The claim is only that **MCP v2** isn't slower.
+- **Self-benchmark, self-approval.** The scripts print the exact numbers on this page. Rerun them on your vault; open an issue if results differ.
+- **Dual-protocol overhead?** Version settles once, at connect. Requests never re-check it.
+- **Nothing got slower at all?** One thing: pinning an **MCP v2** client to the new protocol adds ~110 ms once at connect. Only our test harness pins; shipping apps don't.
+
+## Method
+
+Each pairing spawns `mcpvault <vault> --read-only` over stdio. Cold start is the median of 8 full connect cycles. Per-request numbers are medians on a warm connection after one warmup call. Scripts: [`benchmarks/`](https://github.com/bitbonsai/mcpvault/tree/main/benchmarks) in the repo (also on the [feat/mcp-sdk-v2 branch](https://github.com/bitbonsai/mcpvault/tree/feat/mcp-sdk-v2/benchmarks)).

--- a/website-shibumi/public/index.md
+++ b/website-shibumi/public/index.md
@@ -11,11 +11,12 @@ This MCP server lets Claude, ChatGPT+, and other assistants access your vault. L
 
 ## Announcement
 
-- **The [latest MCP spec](https://modelcontextprotocol.io/specification/latest) is out.** We’re getting MCPVault ready for it. [View feat/mcp-sdk-v2](https://github.com/bitbonsai/mcpvault/tree/feat/mcp-sdk-v2).
+- **MCPVault runs on [MCP v2](https://modelcontextprotocol.io/specification/latest), the latest MCP spec.** Same speed for every client, old and new. [See the benchmarks](https://mcpvault.org/benchmarks.md).
 - **JUST LAUNCHED - Obsidian Skill:** Smart routing across MCP, Obsidian app context, and Git CLI sync is now live, with preflight checks, targeted setup questions, and safe sync defaults. [See skill flows](/skill.md)
 
 ## Recent Updates
 
+- **v0.16.0 (August 2026):** Migrated to **MCP v2**, the official SDK for the 2026-07-28 spec. One process serves both protocol generations at the same speed ([benchmarks](https://mcpvault.org/benchmarks.md)).
 - **v0.15.0 (August 2026):** Added `--read-only` mode, which exposes read tools only and rejects all vault mutations. ([#112](https://github.com/bitbonsai/mcpvault/issues/112), thanks @vdhome-dev)
 - **v0.14.1 (August 2026):** Security: dotfiles and hidden directories are now denied at any vault depth, closing an extension-filter bypass. ([#115](https://github.com/bitbonsai/mcpvault/pull/115), thanks @sadegh)
 - **v0.14.0 (August 2026):** Added `get_note_outline` and `read_note_lines` for navigating and reading targeted sections of large notes without loading the full file. ([#146](https://github.com/bitbonsai/mcpvault/pull/146), thanks @kartik7704)

--- a/website-shibumi/public/llm.txt
+++ b/website-shibumi/public/llm.txt
@@ -10,6 +10,7 @@ Serve `.md` versions of every public page for agents. Use the markdown endpoints
 - `/demo` → `https://mcpvault.org/demo.md`
 - `/how-it-works` → `https://mcpvault.org/how-it-works.md`
 - `/skill` → `https://mcpvault.org/skill.md`
+- `/benchmarks` → `https://mcpvault.org/benchmarks.md`
 
 All markdown files live in `website/public/` inside the repo so they stay in sync with the Astro pages. When citing content, reference the `.md` URL to keep responses reproducible for other agents.
 

--- a/website-shibumi/src/app.tsx
+++ b/website-shibumi/src/app.tsx
@@ -9,6 +9,7 @@ import type { MiddlewareHandler } from "hono";
 import { secureHeaders } from "hono/secure-headers";
 import { join, normalize, resolve, sep } from "node:path";
 import { contentSecurityPolicy } from "./lib/csp";
+import { registerBenchmarksRoute } from "./routes/benchmarks";
 import { registerClientRoute } from "./routes/client";
 import { registerDemoRoute } from "./routes/demo";
 import { registerDownloadsRoute, type DownloadsRouteOptions } from "./routes/downloads";
@@ -144,6 +145,7 @@ export function createApp(options: AppOptions = {}): Hono {
 
   // Features page (Phase 2, group 3).
   registerFeaturesRoute(app, publicDir);
+  registerBenchmarksRoute(app, publicDir);
 
   // Install page (Phase 2, group 4).
   registerInstallRoute(app, publicDir);

--- a/website-shibumi/src/client/alpine.ts
+++ b/website-shibumi/src/client/alpine.ts
@@ -25,6 +25,8 @@
  * never appears in the `Alpine.data(...)` list below.
  */
 import Alpine from "@alpinejs/csp";
+import "./bench-reveal";
+import "./confetti";
 import "./fade-in-observer";
 import { interactiveDemo } from "./interactive-demo";
 import { nav } from "./nav";

--- a/website-shibumi/src/client/bench-reveal.ts
+++ b/website-shibumi/src/client/bench-reveal.ts
@@ -1,0 +1,36 @@
+/**
+ * Grow-in animation trigger for the /benchmarks/ charts.
+ *
+ * Side-effect module like `fade-in-observer`: not an Alpine.data() module,
+ * because it needs no state or events, only a class toggle when a chart
+ * card scrolls into view (`.bench-card.in-view .bench-bar` runs the CSS
+ * `bench-grow` keyframe). No-op on pages without `.bench-card`.
+ */
+function watchBenchCards(): void {
+  const cards = document.querySelectorAll(".bench-card");
+  if (cards.length === 0) return;
+
+  if (!("IntersectionObserver" in window)) {
+    for (const card of cards) card.classList.add("in-view");
+    return;
+  }
+
+  const observer = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries) {
+        if (entry.isIntersecting) {
+          entry.target.classList.add("in-view");
+          observer.unobserve(entry.target);
+        }
+      }
+    },
+    { threshold: 0.3 },
+  );
+  for (const card of cards) observer.observe(card);
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", watchBenchCards, { once: true });
+} else {
+  watchBenchCards();
+}

--- a/website-shibumi/src/client/confetti.ts
+++ b/website-shibumi/src/client/confetti.ts
@@ -1,0 +1,75 @@
+/**
+ * Firework confetti over the home page's MCP v2 banner.
+ *
+ * Side-effect module like `fade-in-observer`: fires once per browser
+ * session (sessionStorage gate) when `#spec-confetti` is present, skipped
+ * under prefers-reduced-motion. Three radial bursts across the banner,
+ * evenly spaced angles with jitter, decelerating and fading in place (no
+ * gravity pull); the last burst lingers ~700 ms longer. Pieces animate via
+ * the Web Animations API and remove themselves. No-op on other pages.
+ */
+const COLORS = ["#8b5cf6", "#06b6d4", "#d97706", "#22c55e", "#fafafa"];
+const BURSTS = [
+  { x: 25, delay: 0, linger: 0 },
+  { x: 50, delay: 140, linger: 0 },
+  { x: 75, delay: 280, linger: 700 },
+];
+const PIECES = 42;
+
+function specConfetti(): void {
+  const layer = document.getElementById("spec-confetti");
+  if (!layer || layer.dataset.done) return;
+  if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+  try {
+    if (sessionStorage.getItem("spec-confetti-shown")) return;
+    sessionStorage.setItem("spec-confetti-shown", "1");
+  } catch {
+    // Private mode: fall back to once per page view.
+  }
+  layer.dataset.done = "1";
+
+  for (const burst of BURSTS) {
+    for (let i = 0; i < PIECES; i++) {
+      const piece = document.createElement("span");
+      const size = 4 + Math.random() * 4;
+      piece.style.cssText = [
+        "position:absolute",
+        "top:50%",
+        `left:${burst.x}%`,
+        `width:${size}px`,
+        `height:${size * 0.6}px`,
+        `background:${COLORS[i % COLORS.length]}`,
+        "border-radius:1px",
+      ].join(";");
+      layer.appendChild(piece);
+
+      const angle = (i / PIECES) * Math.PI * 2 + (Math.random() - 0.5) * 0.5;
+      const distance = 70 + Math.random() * 150;
+      const dx = Math.cos(angle) * distance;
+      const dy = Math.sin(angle) * distance;
+      const spin = (Math.random() - 0.5) * 720;
+      piece
+        .animate(
+          [
+            { transform: "translate(0,0) rotate(0deg) scale(1)", opacity: 1 },
+            { transform: `translate(${dx * 0.85}px,${dy * 0.85}px) rotate(${spin * 0.7}deg) scale(1)`, opacity: 1, offset: 0.6 },
+            { transform: `translate(${dx}px,${dy}px) rotate(${spin}deg) scale(0.6)`, opacity: 0 },
+          ],
+          {
+            duration: 700 + Math.random() * 300 + burst.linger,
+            delay: burst.delay,
+            easing: "cubic-bezier(0.1, 0.8, 0.3, 1)",
+            fill: "forwards",
+          },
+        )
+        .finished.then(() => piece.remove())
+        .catch(() => piece.remove());
+    }
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", specConfetti, { once: true });
+} else {
+  specConfetti();
+}

--- a/website-shibumi/src/components/BenchmarkCharts.tsx
+++ b/website-shibumi/src/components/BenchmarkCharts.tsx
@@ -1,0 +1,213 @@
+/**
+ * Benchmark bar charts for the /benchmarks/ page. Ported from
+ * website/src/components/BenchmarkCharts.astro.
+ *
+ * Bars are server-rendered markup; the grow-in animation is added by the
+ * `bench-reveal` client module (IntersectionObserver toggles `.in-view` on
+ * each `.bench-card`), keeping the page free of inline scripts under CSP.
+ *
+ * Measured 2026-08-17 on macOS (Darwin 25.6), Node v26.7.0, against a real
+ * vault (381 notes, 84 folders, 3.2 MB) over stdio in read-only mode.
+ * Scripts: benchmarks/ in the repo root.
+ */
+
+interface Stat {
+  median: number;
+  p95: number;
+  n: number;
+}
+
+interface Pairing {
+  name: string;
+  short: string;
+  detail: string;
+  coldStart: Stat;
+  tools: Record<string, Stat>;
+}
+
+const PAIRINGS: Pairing[] = [
+  {
+    name: "MCPVault today",
+    short: "today",
+    detail: "the current npm release, measured as a baseline",
+    coldStart: { median: 107.3, p95: 155.5, n: 8 },
+    tools: {
+      "tools/list": { median: 0.15, p95: 0.28, n: 50 },
+      get_vault_stats: { median: 12.13, p95: 13.95, n: 50 },
+      read_note: { median: 0.46, p95: 0.84, n: 50 },
+      list_directory: { median: 0.45, p95: 0.66, n: 50 },
+      search_notes: { median: 85.53, p95: 107.44, n: 20 },
+    },
+  },
+  {
+    name: "MCP v2 with today’s apps",
+    short: "MCP v2, today’s apps",
+    detail: "the MCP v2 build answering the apps you already use, unchanged (Claude Desktop, Cursor, and friends)",
+    coldStart: { median: 109.8, p95: 116.8, n: 8 },
+    tools: {
+      "tools/list": { median: 0.14, p95: 0.28, n: 50 },
+      get_vault_stats: { median: 11.4, p95: 12.2, n: 50 },
+      read_note: { median: 0.43, p95: 0.58, n: 50 },
+      list_directory: { median: 0.43, p95: 0.49, n: 50 },
+      search_notes: { median: 84.33, p95: 86.4, n: 20 },
+    },
+  },
+  {
+    name: "MCP v2 with new apps",
+    short: "MCP v2, new apps",
+    detail: "the MCP v2 build with an app on the new SDK (2.0.0), how connections will look as the ecosystem updates",
+    coldStart: { median: 105.8, p95: 107.8, n: 8 },
+    tools: {
+      "tools/list": { median: 0.17, p95: 0.34, n: 50 },
+      get_vault_stats: { median: 11.66, p95: 12.33, n: 50 },
+      read_note: { median: 0.45, p95: 0.65, n: 50 },
+      list_directory: { median: 0.46, p95: 0.64, n: 50 },
+      search_notes: { median: 85.62, p95: 88.15, n: 20 },
+    },
+  },
+];
+
+// Validated for CVD separation and 3:1 contrast on the #171717 card surface.
+const COLORS = ["#0891b2", "#8b5cf6", "#d97706"];
+const TOOLS = Object.keys(PAIRINGS[0]?.tools ?? {});
+
+// Round an axis limit up to a clean 1/1.2/1.5/2/2.5/5/10 step, e.g. 109.8 -> 120.
+function niceCeil(v: number): number {
+  const mag = 10 ** Math.floor(Math.log10(v));
+  for (const step of [1, 1.2, 1.5, 2, 2.5, 5, 10]) {
+    if (v <= step * mag) return step * mag;
+  }
+  return 10 * mag;
+}
+
+const fmt = (v: number) => (v >= 10 ? v.toFixed(1) : v.toFixed(2));
+
+interface ChartRow {
+  pairing: Pairing;
+  stat: Stat;
+  color: string;
+}
+
+interface ChartProps {
+  title: string;
+  unit?: string;
+  rows: ChartRow[];
+  compact?: boolean;
+}
+
+function chartRows(pick: (p: Pairing) => Stat): ChartRow[] {
+  return PAIRINGS.map((pairing, i) => ({ pairing, stat: pick(pairing), color: COLORS[i] ?? "#8b5cf6" }));
+}
+
+function BarChart({ title, unit, rows, compact }: ChartProps) {
+  const axisMax = niceCeil(Math.max(...rows.map((r) => r.stat.median)) * 1.02);
+  return (
+    <figure class={`bench-card${compact ? " bench-card-compact" : ""}`}>
+      <figcaption>
+        {title}
+        {unit ? <span class="bench-unit"> · {unit}</span> : null}
+      </figcaption>
+      {rows.map((row, i) => (
+        <div class="bench-row">
+          <span class="bench-label">{row.pairing.short}</span>
+          <div
+            class="bench-track"
+            title={`${row.pairing.name}: median ${fmt(row.stat.median)} ms, p95 ${fmt(row.stat.p95)} ms, n=${row.stat.n}`}
+          >
+            <div
+              class="bench-bar"
+              style={`width:${(row.stat.median / axisMax) * 100}%;background:${row.color};animation-delay:${i * 80}ms`}
+            ></div>
+          </div>
+          {compact ? null : <span class="bench-value">{fmt(row.stat.median)}</span>}
+        </div>
+      ))}
+      {compact ? (
+        <div class="bench-chips">
+          {rows.map((row) => (
+            <span class="bench-chip">
+              <span class="bench-swatch" style={`background:${row.color}`} aria-hidden="true"></span>
+              <span class="bench-chip-value">{fmt(row.stat.median)}</span>
+            </span>
+          ))}
+          <span class="bench-chip-unit">ms</span>
+        </div>
+      ) : (
+        <div class="bench-axis">
+          <span>0</span>
+          <span>{axisMax} ms</span>
+        </div>
+      )}
+    </figure>
+  );
+}
+
+export function BenchmarkCharts() {
+  return (
+    <div class="bench-charts">
+      <BarChart
+        title="Cold start"
+        unit="spawn to first response, median ms, lower is better"
+        rows={chartRows((p) => p.coldStart)}
+      />
+
+      <h3 class="bench-group-title">
+        Per request, warm connection <span class="bench-unit">· median ms</span>
+      </h3>
+      <div class="bench-grid">
+        {TOOLS.map((tool) => (
+          <BarChart title={tool} rows={chartRows((p) => p.tools[tool] ?? { median: 0, p95: 0, n: 0 })} compact />
+        ))}
+      </div>
+
+      <div class="bench-legend">
+        {PAIRINGS.map((p, i) => (
+          <span class="bench-legend-item">
+            <span class="bench-swatch" style={`background:${COLORS[i] ?? "#8b5cf6"}`} aria-hidden="true"></span>
+            <span>
+              <strong>{p.name}</strong>: {p.detail}
+            </span>
+          </span>
+        ))}
+      </div>
+
+      <details class="bench-table-details">
+        <summary>Full numbers (median and p95, in ms)</summary>
+        <div class="bench-table-scroll">
+          <table>
+            <thead>
+              <tr>
+                <th>metric</th>
+                {PAIRINGS.map((p) => (
+                  <th>{p.name}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>cold start (n=8)</td>
+                {PAIRINGS.map((p) => (
+                  <td>
+                    {p.coldStart.median} · p95 {p.coldStart.p95}
+                  </td>
+                ))}
+              </tr>
+              {TOOLS.map((tool) => (
+                <tr>
+                  <td>
+                    {tool} (n={PAIRINGS[0]?.tools[tool]?.n ?? 0})
+                  </td>
+                  {PAIRINGS.map((p) => (
+                    <td>
+                      {p.tools[tool]?.median} · p95 {p.tools[tool]?.p95}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/website-shibumi/src/components/SpecPreviewCallout.tsx
+++ b/website-shibumi/src/components/SpecPreviewCallout.tsx
@@ -7,12 +7,12 @@
 import { ArrowRightIcon, GitBranchIcon } from "./icons";
 
 const SPEC_URL = "https://modelcontextprotocol.io/specification/latest";
-const BRANCH_URL = "https://github.com/bitbonsai/mcpvault/tree/feat/mcp-sdk-v2";
 
 export function SpecPreviewCallout() {
   return (
     <section data-component="spec-preview-callout" aria-label="Latest MCP specification development preview">
-      <div class="callout-inner">
+      <div class="callout-inner" style="position:relative">
+        <div id="spec-confetti" style="position:absolute;inset:0;pointer-events:none;z-index:20" aria-hidden="true"></div>
         <div class="callout-card">
           <div class="callout-row">
             <div class="callout-message">
@@ -22,19 +22,19 @@ export function SpecPreviewCallout() {
 
               <p class="callout-text">
                 <span class="callout-headline">
-                  The{" "}
+                  MCPVault runs on{" "}
                   <a href={SPEC_URL} target="_blank" rel="noopener noreferrer" class="spec-link">
-                    latest MCP spec
-                  </a>{" "}
-                  is out.
+                    MCP v2
+                  </a>
+                  , the latest spec.
                 </span>
-                <span class="callout-short"> We’re getting ready for it.</span>
-                <span class="callout-long"> We’re getting MCPVault ready for it.</span>
+                <span class="callout-short"> Same speed, every client.</span>
+                <span class="callout-long"> Same speed for every client, old and new.</span>
               </p>
             </div>
 
-            <a href={BRANCH_URL} target="_blank" rel="noopener noreferrer" aria-label="View the feat/mcp-sdk-v2 branch" class="work-link">
-              <span class="work-link-label">View feat/mcp-sdk-v2</span>
+            <a href="/benchmarks/" aria-label="See the MCP v2 benchmarks" class="work-link">
+              <span class="work-link-label">See the benchmarks</span>
               <ArrowRightIcon className="icon" />
             </a>
           </div>

--- a/website-shibumi/src/components/UpdateCallout.tsx
+++ b/website-shibumi/src/components/UpdateCallout.tsx
@@ -38,6 +38,19 @@ interface Update {
 
 const OLDER_UPDATES: Update[] = [
   {
+    version: "v0.15.0",
+    date: "August 2026",
+    body: (
+      <>
+        Added <code>--read-only</code> mode, which exposes read tools only and rejects all vault mutations (
+        <a href="https://github.com/bitbonsai/mcpvault/issues/112" target="_blank" rel="noopener noreferrer">
+          #112
+        </a>
+        , thanks @vdhome-dev)
+      </>
+    ),
+  },
+  {
     version: "v0.14.1",
     date: "August 2026",
     body: (
@@ -382,7 +395,7 @@ export function UpdateCallout() {
         <div class="callout-body">
           <div class="updates-heading">
             <h3>
-              Recent Updates <span class="version-pill">v0.15.0</span>
+              Recent Updates <span class="version-pill">v0.16.0</span>
             </h3>
             <button
               type="button"
@@ -408,12 +421,8 @@ export function UpdateCallout() {
           </div>
 
           <p class="latest-update">
-            <span class="entry-version">v0.15.0 (August 2026):</span> Added <code>--read-only</code> mode, which exposes read tools only and rejects all
-            vault mutations (
-            <a href="https://github.com/bitbonsai/mcpvault/issues/112" target="_blank" rel="noopener noreferrer">
-              #112
-            </a>
-            , thanks @vdhome-dev)
+            <span class="entry-version">v0.16.0 (August 2026):</span> Migrated to <strong>MCP v2</strong>, the official SDK for the 2026-07-28 spec. One
+            process serves both protocol generations at the same speed (<a href="/benchmarks/">benchmarks</a>)
           </p>
 
           <div id="older-updates" class="older-updates is-collapsed" data-updates-panel x-bind:class="{ 'is-expanded': expanded, 'is-collapsed': !expanded }">

--- a/website-shibumi/src/pages/Benchmarks.tsx
+++ b/website-shibumi/src/pages/Benchmarks.tsx
@@ -1,0 +1,180 @@
+/**
+ * Benchmarks page. Ported from website/src/pages/benchmarks.astro.
+ *
+ * Composition: Nav, hero + TL;DR, BenchmarkCharts, prose sections
+ * (Why should we move? / HTTP / Method), skeptics FAQ, Footer.
+ */
+import { BenchmarkCharts } from "../components/BenchmarkCharts";
+import { Footer } from "../components/Footer";
+import { Nav } from "../components/Nav";
+import { Layout } from "../layouts/Layout";
+
+const SPEC_URL = "https://modelcontextprotocol.io/specification/latest";
+const SCRIPTS_URL = "https://github.com/bitbonsai/mcpvault/tree/main/benchmarks";
+const ISSUE_URL = "https://github.com/bitbonsai/mcpvault/issues/49";
+
+interface FaqItem {
+  q: string;
+  a: unknown;
+}
+
+const FAQ_ITEMS: FaqItem[] = [
+  {
+    q: "Sub-millisecond tool calls? That looks made up.",
+    a: "It's stdio on the same machine: no network, and the file is already in the OS cache. The number isolates server processing, the only part the SDK swap could change.",
+  },
+  {
+    q: "Eight cold starts and twenty searches is a tiny sample.",
+    a: "True. It's enough to compare medians of a quiet local process, and it's why we claim a tie, never a speedup. Every p95 is in the table above.",
+  },
+  {
+    q: "MCP v2 wins some rows. Convenient.",
+    a: (
+      <>
+        Noise. Those differences flip between runs. The claim is only that <strong>MCP v2</strong> isn't slower.
+      </>
+    ),
+  },
+  {
+    q: "You benchmarked your own project and concluded it's fine.",
+    a: "The scripts are in the repo and print the exact numbers on this page. Rerun them on your own vault; if you get different results, open an issue.",
+  },
+  {
+    q: "Two protocol versions in one server sounds like per-request overhead.",
+    a: "The version is settled once, when the client connects. Requests never re-check it, which is what the flat per-request numbers show.",
+  },
+  {
+    q: "So nothing at all got slower? Really?",
+    a: (
+      <>
+        One thing: pinning an <strong>MCP v2</strong> client to the new protocol version adds about 110 ms, once, at
+        connect. Only our test harness does that; shipping apps don't pin. Publishing it because you'd find it anyway.
+      </>
+    ),
+  },
+];
+
+export interface BenchmarksPageProps {
+  currentPath: string;
+  version: string;
+}
+
+export function BenchmarksPage({ currentPath, version }: BenchmarksPageProps) {
+  return (
+    <Layout
+      title="MCP v2 Benchmarks"
+      description="MCPVault already runs on the new MCP specification (2026-07-28). Benchmarks show identical speed for every client, old and new."
+      canonical="https://mcpvault.org/benchmarks"
+      page="benchmarks"
+      pageStylesheet="/styles/benchmarks.css"
+      clientScript="/client/alpine.js"
+      version={version}
+    >
+      <Nav currentPath={currentPath} version={version} />
+
+      <main id="main-content" data-component="benchmarks">
+        <section class="bench-section bench-hero">
+          <div class="bench-container">
+            <h1>Ready for the next MCP. Same speed.</h1>
+            <p>
+              The Model Context Protocol published its{" "}
+              <a href={SPEC_URL} target="_blank" rel="noopener noreferrer">
+                2026-07-28 specification
+              </a>{" "}
+              in July 2026. MCPVault runs on the new official SDK, which we call <strong>MCP v2</strong>, and serves
+              both protocol generations from a single process: each client gets an answer in whichever version it
+              speaks. Your current setup keeps working as is, and when your favorite app moves to the new protocol,
+              MCPVault is already there.
+            </p>
+            <p>We benchmarked the upgrade before shipping it. Three pairings, one real vault (381 notes), everything over stdio.</p>
+
+            <aside class="bench-tldr" aria-label="Summary">
+              <p class="bench-tldr-label">TL;DR</p>
+              <p>
+                Benchmarks of MCPVault on <strong>MCP v2</strong>: ~107 ms to connect and identical per-request speed,
+                whether the app talks the old protocol or the new one. Below: the numbers, why we moved, what stateless
+                HTTP opens up, and answers for skeptics.
+              </p>
+            </aside>
+          </div>
+        </section>
+
+        <section class="bench-section" aria-label="Benchmark results">
+          <div class="bench-container">
+            <BenchmarkCharts />
+          </div>
+        </section>
+
+        <section class="bench-section">
+          <div class="bench-container bench-prose">
+            <div>
+              <h2>Why should we move?</h2>
+              <ul>
+                <li>
+                  <strong>Every client, one server.</strong> The <strong>MCP v2</strong> build detects what each client
+                  speaks during the opening exchange. Apps on the current protocol and apps on 2026-07-28 connect to
+                  the same MCPVault.
+                </li>
+                <li>
+                  <strong>The maintained SDK line.</strong> New MCP features, fixes, and security patches land in the{" "}
+                  <strong>MCP v2</strong> packages first. Staying on the 1.x SDK means those reach you late, or never.
+                </li>
+                <li>
+                  <strong>Richer tool definitions ahead.</strong> The new spec supports full JSON Schema 2020-12, so
+                  tool inputs can be described more precisely as clients adopt it.
+                </li>
+              </ul>
+            </div>
+
+            <div>
+              <h2>What this opens up: HTTP</h2>
+              <p>
+                The 2026-07-28 spec makes the HTTP transport stateless: servers stop tracking per-client sessions, so
+                an MCP server can sit behind any ordinary load balancer and serve many clients from plain
+                infrastructure. For MCPVault that means a future HTTP mode, your vault reachable by AI assistants that
+                never touch your filesystem, without the session bookkeeping that made the old approach fragile.
+                MCPVault stays local-first by default; HTTP would ship as a separate opt-in package built on this{" "}
+                <strong>MCP v2</strong> core. That work is tracked in{" "}
+                <a href={ISSUE_URL} target="_blank" rel="noopener noreferrer">
+                  issue #49
+                </a>
+                .
+              </p>
+            </div>
+
+            <div>
+              <h2>Method</h2>
+              <p>
+                Each pairing spawns <code>mcpvault &lt;vault&gt; --read-only</code> over stdio. Cold start is the
+                median of 8 full connect cycles, spawn to first response. Per-request numbers are medians on a warm
+                connection after one warmup call (50 iterations per tool, 20 for search_notes). Measured 2026-08-17 on
+                macOS, Node 26, SDK 1.30.0 vs 2.0.0. The scripts live in the repo's{" "}
+                <a href={SCRIPTS_URL} target="_blank" rel="noopener noreferrer">
+                  benchmarks folder
+                </a>
+                , so you can rerun them against your own vault.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        <section class="bench-section bench-faq" aria-label="Frequently asked questions">
+          <div class="bench-container">
+            <h2>For the skeptics</h2>
+            <p class="bench-faq-intro">Fair questions a developer should ask about a project benchmarking itself.</p>
+            <div class="bench-faq-list">
+              {FAQ_ITEMS.map((item) => (
+                <details>
+                  <summary>{item.q}</summary>
+                  <p>{item.a}</p>
+                </details>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <Footer />
+      </main>
+    </Layout>
+  );
+}

--- a/website-shibumi/src/routes/benchmarks.tsx
+++ b/website-shibumi/src/routes/benchmarks.tsx
@@ -1,0 +1,35 @@
+/**
+ * `GET /benchmarks/` -- the MCP v2 benchmarks page.
+ *
+ * Shape mirrors routes/features.tsx: trailing-slash form to match
+ * `SITE_ROUTES` (routes/seo.ts), and `Accept: text/markdown` (without
+ * `text/html`) serves `public/benchmarks.md` verbatim.
+ */
+import type { Hono } from "hono";
+import { join } from "node:path";
+import { prefersMarkdown } from "../lib/content-negotiation";
+import { packageVersion } from "../lib/version";
+import { BenchmarksPage } from "../pages/Benchmarks";
+
+const CACHE_CONTROL = "public, max-age=0, must-revalidate";
+
+export function registerBenchmarksRoute(app: Hono, publicDir: string): void {
+  app.get("/benchmarks/", async (c) => {
+    if (prefersMarkdown(c.req.header("accept"))) {
+      const file = Bun.file(join(publicDir, "benchmarks.md"));
+      if (await file.exists()) {
+        return new Response(file, {
+          status: 200,
+          headers: {
+            "content-type": "text/markdown; charset=utf-8",
+            "cache-control": CACHE_CONTROL,
+          },
+        });
+      }
+    }
+
+    return c.html(<BenchmarksPage currentPath={c.req.path} version={packageVersion} />, 200, {
+      "cache-control": CACHE_CONTROL,
+    });
+  });
+}

--- a/website-shibumi/src/routes/seo.ts
+++ b/website-shibumi/src/routes/seo.ts
@@ -17,7 +17,7 @@ import type { Hono } from "hono";
 export const SITE_URL = "https://mcpvault.org";
 
 /** Every public page route, trailing-slash form (matches PRs #187/#188). */
-export const SITE_ROUTES: readonly string[] = ["/", "/install/", "/features/", "/demo/", "/how-it-works/", "/skill/"];
+export const SITE_ROUTES: readonly string[] = ["/", "/install/", "/features/", "/demo/", "/how-it-works/", "/skill/", "/benchmarks/"];
 
 const XML_CACHE_CONTROL = "public, max-age=3600";
 const ROBOTS_CACHE_CONTROL = "public, max-age=14400, must-revalidate";

--- a/website-shibumi/src/styles/benchmarks.css
+++ b/website-shibumi/src/styles/benchmarks.css
@@ -1,0 +1,403 @@
+/* Benchmarks page (/benchmarks/). Ported from the Astro/Tailwind version:
+ * minor-third type scale off the 16px body, glassy cards, median-scaled
+ * bars with a grow-in animation driven by .in-view (bench-reveal client
+ * module). */
+
+.bench-section {
+  padding: 0 1rem 2rem;
+}
+
+.bench-hero {
+  padding-top: 7rem;
+}
+
+.bench-faq {
+  padding-bottom: 4rem;
+}
+
+.bench-container {
+  max-width: 56rem;
+  margin: 0 auto;
+}
+
+.bench-hero h1 {
+  font-size: 2.074rem;
+  line-height: 1.2;
+  font-weight: 700;
+  color: var(--color-foreground);
+  margin: 0 0 1rem;
+}
+
+.bench-hero p,
+.bench-prose p,
+.bench-prose li,
+.bench-faq p {
+  color: var(--color-muted-foreground);
+  line-height: 1.65;
+  max-width: 48rem;
+}
+
+.bench-hero p {
+  margin: 0 0 1rem;
+}
+
+.bench-hero a,
+.bench-prose a {
+  color: #a78bfa;
+  text-decoration: underline;
+  text-decoration-color: rgba(167, 139, 250, 0.5);
+  text-underline-offset: 0.15em;
+  transition: color 0.2s ease, text-decoration-color 0.2s ease;
+}
+
+.bench-hero a:hover,
+.bench-prose a:hover {
+  color: #c4b5fd;
+  text-decoration-color: #c4b5fd;
+}
+
+.bench-hero strong,
+.bench-prose strong,
+.bench-faq strong {
+  color: var(--color-foreground);
+  font-weight: 600;
+}
+
+.bench-tldr {
+  margin-top: 1.5rem;
+  border: 1px solid rgba(167, 139, 250, 0.25);
+  border-radius: 0.75rem;
+  background: rgba(23, 23, 23, 0.4);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 1.25rem;
+}
+
+.bench-tldr-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: #a78bfa;
+  margin: 0 0 0.5rem;
+}
+
+.bench-tldr p:last-child {
+  margin: 0;
+  color: var(--color-foreground);
+}
+
+/* Charts */
+
+.bench-charts > * + * {
+  margin-top: 2rem;
+}
+
+.bench-card {
+  margin: 0;
+  border: 1px solid rgba(38, 38, 38, 0.5);
+  border-radius: 0.75rem;
+  background: rgba(23, 23, 23, 0.4);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 1rem 1.25rem;
+}
+
+.bench-card figcaption {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+  margin-bottom: 0.75rem;
+}
+
+.bench-unit {
+  font-weight: 400;
+  color: var(--color-muted-foreground);
+  font-size: 0.875rem;
+}
+
+.bench-group-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+  margin: 0 0 0.75rem;
+}
+
+.bench-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 640px) {
+  .bench-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  .bench-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+.bench-row {
+  display: grid;
+  grid-template-columns: 9.5rem 1fr 3.5rem;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+.bench-card-compact .bench-row {
+  grid-template-columns: 8.5rem 1fr;
+  gap: 0.5rem;
+}
+
+.bench-label {
+  text-align: right;
+  font-size: 0.75rem;
+  color: var(--color-muted-foreground);
+}
+
+.bench-card-compact .bench-label {
+  font-size: 0.6875rem;
+}
+
+.bench-track {
+  position: relative;
+  height: 1.25rem;
+  background: rgba(148, 163, 184, 0.07);
+  border-radius: 0 0.25rem 0.25rem 0;
+}
+
+.bench-bar {
+  position: absolute;
+  top: 0.125rem;
+  height: 1rem;
+  border-radius: 0 0.25rem 0.25rem 0;
+  transform-origin: left center;
+  transform: scaleX(0);
+}
+
+.bench-card.in-view .bench-bar {
+  animation: bench-grow 0.7s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+
+@keyframes bench-grow {
+  to {
+    transform: scaleX(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .bench-bar {
+    transform: none;
+  }
+
+  .bench-card.in-view .bench-bar {
+    animation: none;
+  }
+}
+
+.bench-value {
+  text-align: right;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+  color: var(--color-muted-foreground);
+}
+
+.bench-axis {
+  display: flex;
+  justify-content: space-between;
+  border-top: 1px solid var(--color-border);
+  margin-top: 0.5rem;
+  padding-top: 0.25rem;
+  font-size: 0.6875rem;
+  font-variant-numeric: tabular-nums;
+  color: rgba(163, 163, 163, 0.7);
+}
+
+.bench-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem 0.75rem;
+  border-top: 1px solid var(--color-border);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+  font-size: 0.6875rem;
+  color: var(--color-muted-foreground);
+}
+
+.bench-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+.bench-chip-value {
+  font-variant-numeric: tabular-nums;
+  color: var(--color-foreground);
+}
+
+.bench-chip-unit {
+  margin-left: auto;
+}
+
+.bench-swatch {
+  display: inline-block;
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 0.125rem;
+  flex-shrink: 0;
+}
+
+.bench-legend {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  color: var(--color-muted-foreground);
+}
+
+.bench-legend-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.bench-legend-item .bench-swatch {
+  width: 0.625rem;
+  height: 0.625rem;
+  margin-top: 0.3rem;
+}
+
+.bench-legend strong {
+  color: var(--color-foreground);
+  font-weight: 600;
+}
+
+/* Full-numbers table + FAQ share the glassy details card. */
+
+.bench-table-details,
+.bench-faq-list details {
+  border: 1px solid rgba(38, 38, 38, 0.5);
+  border-radius: 0.75rem;
+  background: rgba(23, 23, 23, 0.4);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 0.75rem 1rem;
+}
+
+.bench-table-details summary,
+.bench-faq-list summary {
+  cursor: pointer;
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+  list-style: none;
+}
+
+.bench-table-details summary::-webkit-details-marker,
+.bench-faq-list summary::-webkit-details-marker {
+  display: none;
+}
+
+.bench-table-scroll {
+  margin-top: 0.75rem;
+  overflow-x: auto;
+}
+
+.bench-table-scroll table {
+  width: 100%;
+  min-width: 34rem;
+  border-collapse: collapse;
+  text-align: left;
+  font-size: 0.875rem;
+}
+
+.bench-table-scroll th {
+  padding: 0.5rem 1rem 0.5rem 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-muted-foreground);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.bench-table-scroll td {
+  padding: 0.5rem 1rem 0.5rem 0;
+  color: var(--color-muted-foreground);
+  font-variant-numeric: tabular-nums;
+  border-bottom: 1px solid rgba(38, 38, 38, 0.6);
+}
+
+.bench-table-scroll td:first-child {
+  color: var(--color-foreground);
+  font-variant-numeric: normal;
+}
+
+.bench-table-scroll tr:last-child td {
+  border-bottom: none;
+}
+
+/* Prose sections */
+
+.bench-prose > div + div {
+  margin-top: 1.5rem;
+}
+
+.bench-prose h2,
+.bench-faq h2 {
+  font-size: 1.44rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+  margin: 0 0 0.75rem;
+}
+
+.bench-prose p {
+  margin: 0 0 1rem;
+}
+
+.bench-prose p:last-child {
+  margin-bottom: 0;
+}
+
+.bench-prose ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.bench-prose code {
+  font-family: "JetBrains Mono", "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 0.85em;
+  padding: 0.14em 0.42em;
+  border: 1px solid rgba(148, 163, 184, 0.14);
+  border-radius: 0.45rem;
+  background: rgba(148, 163, 184, 0.1);
+}
+
+/* Skeptics FAQ */
+
+.bench-faq-intro {
+  margin: 0 0 1rem;
+}
+
+.bench-faq-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.bench-faq-list details {
+  padding: 1.25rem;
+}
+
+.bench-faq-list details p {
+  margin: 0.75rem 0 0;
+}

--- a/website-shibumi/test/routes/home.test.tsx
+++ b/website-shibumi/test/routes/home.test.tsx
@@ -63,7 +63,7 @@ describe("GET / (HTML)", () => {
   test("renders SpecPreviewCallout, UpdateCallout, and NewsletterSignup", async () => {
     const body = await (await app.request("/")).text();
     expect(body).toContain('data-component="spec-preview-callout"');
-    expect(body).toContain("latest MCP spec");
+    expect(body).toContain("MCP v2");
     expect(body).toContain('data-component="update-callout"');
     expect(body).toContain("Recent Updates");
     expect(body).toContain('data-component="newsletter-signup"');


### PR DESCRIPTION
Production builds from website-shibumi/; all of today's website/ work was invisible. This ports the benchmarks page, banner, confetti, and 0.16.0 release copy to the Hono/Alpine stack. Typecheck clean, 302 tests green, routes smoke-tested locally including markdown negotiation.