### PR TITLE
Use trailing slashes for page URLs

### DIFF
--- a/website-shibumi/public/index.md
+++ b/website-shibumi/public/index.md
@@ -6,7 +6,7 @@
 
 MCPVault reads, searches, and edits local vault files. Obsidian can stay closed, and frontmatter updates preserve existing formatting.
 
-- [Installation](/install) - Configuration examples for supported clients
+- [Installation](/install/) - Configuration examples for supported clients
 - [View on GitHub](https://github.com/bitbonsai/mcpvault)
 
 ## Announcement

--- a/website-shibumi/public/llm.txt
+++ b/website-shibumi/public/llm.txt
@@ -5,12 +5,12 @@ Each public HTML page has a Markdown mirror with the same product information an
 ## Pages
 
 - `/` -> `https://mcpvault.org/index.md`
-- `/install` -> `https://mcpvault.org/install.md`
-- `/features` -> `https://mcpvault.org/features.md`
-- `/demo` -> `https://mcpvault.org/demo.md`
-- `/how-it-works` -> `https://mcpvault.org/how-it-works.md`
-- `/skill` -> `https://mcpvault.org/skill.md`
-- `/benchmarks` -> `https://mcpvault.org/benchmarks.md`
+- `/install/` -> `https://mcpvault.org/install.md`
+- `/features/` -> `https://mcpvault.org/features.md`
+- `/demo/` -> `https://mcpvault.org/demo.md`
+- `/how-it-works/` -> `https://mcpvault.org/how-it-works.md`
+- `/skill/` -> `https://mcpvault.org/skill.md`
+- `/benchmarks/` -> `https://mcpvault.org/benchmarks.md`
 
 Markdown source files live in `website-shibumi/public/` in the repository.
 

--- a/website-shibumi/src/app.tsx
+++ b/website-shibumi/src/app.tsx
@@ -117,7 +117,7 @@ export function createApp(options: AppOptions = {}): Hono {
   // Production 301s bare page paths to their trailing-slash form (Cloudflare
   // rules from PRs #187/#188); replicated here so behavior survives cutover.
   // Only the known page routes redirect — anything else must fall through to 404.
-  const trailingSlashPages = new Set(["/install", "/features", "/demo", "/how-it-works", "/skill"]);
+  const trailingSlashPages = new Set(["/install", "/features", "/demo", "/how-it-works", "/skill", "/benchmarks"]);
   app.use("*", async (c, next) => {
     const { pathname, search } = new URL(c.req.url);
     if (trailingSlashPages.has(pathname)) {

--- a/website-shibumi/src/app.tsx
+++ b/website-shibumi/src/app.tsx
@@ -17,7 +17,7 @@ import { registerFeaturesRoute } from "./routes/features";
 import { registerHomeRoute } from "./routes/home";
 import { registerHowItWorksRoute } from "./routes/how-it-works";
 import { registerInstallRoute } from "./routes/install";
-import { registerSeoRoutes, SITE_URL } from "./routes/seo";
+import { registerSeoRoutes, SITE_ROUTES, SITE_URL } from "./routes/seo";
 import { registerSkillRoute } from "./routes/skill";
 import { registerSubscribeRoute, type SubscribeRouteOptions } from "./routes/subscribe";
 import { registerUnsubscribeRoute } from "./routes/unsubscribe";
@@ -117,7 +117,7 @@ export function createApp(options: AppOptions = {}): Hono {
   // Production 301s bare page paths to their trailing-slash form (Cloudflare
   // rules from PRs #187/#188); replicated here so behavior survives cutover.
   // Only the known page routes redirect — anything else must fall through to 404.
-  const trailingSlashPages = new Set(["/install", "/features", "/demo", "/how-it-works", "/skill", "/benchmarks"]);
+  const trailingSlashPages = new Set(SITE_ROUTES.filter((path) => path !== "/").map((path) => path.slice(0, -1)));
   app.use("*", async (c, next) => {
     const { pathname, search } = new URL(c.req.url);
     if (trailingSlashPages.has(pathname)) {

--- a/website-shibumi/src/components/ComparisonTable.tsx
+++ b/website-shibumi/src/components/ComparisonTable.tsx
@@ -158,7 +158,7 @@ export function ComparisonTable() {
         <div class="comparison-cta fade-in-on-scroll">
           <div class="comparison-cta-card">
             <div class="comparison-cta-links">
-              <a href="/install" class="comparison-cta-primary">
+              <a href="/install/" class="comparison-cta-primary">
                 <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                 </svg>

--- a/website-shibumi/src/components/Footer.tsx
+++ b/website-shibumi/src/components/Footer.tsx
@@ -34,11 +34,11 @@ export function Footer() {
           <div>
             <h3>Quick Links</h3>
             <div class="footer-link-list">
-              <a href="/install">Installation</a>
-              <a href="/demo">Demo</a>
-              <a href="/features">Features</a>
-              <a href="/how-it-works">How It Works</a>
-              <a href="/skill">Skill</a>
+              <a href="/install/">Installation</a>
+              <a href="/demo/">Demo</a>
+              <a href="/features/">Features</a>
+              <a href="/how-it-works/">How It Works</a>
+              <a href="/skill/">Skill</a>
             </div>
           </div>
 

--- a/website-shibumi/src/components/Hero.tsx
+++ b/website-shibumi/src/components/Hero.tsx
@@ -45,7 +45,7 @@ export function Hero({ version }: HeroProps) {
         <p class="hero-subtext">MCPVault reads, searches, and edits local vault files. Obsidian can stay closed, and frontmatter updates preserve existing formatting.</p>
 
         <div class="hero-cta">
-          <a href="/install" class="btn-primary">
+          <a href="/install/" class="btn-primary">
             <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"></path>
             </svg>

--- a/website-shibumi/src/components/HowItWorks.tsx
+++ b/website-shibumi/src/components/HowItWorks.tsx
@@ -203,7 +203,7 @@ export async function HowItWorksSection() {
             <div class="how-it-works-cta-text">
               <h3 class="how-it-works-cta-title">What these examples cover</h3>
               <p class="how-it-works-cta-description">The prompts show search, batch reads, and frontmatter updates from request to response.</p>
-              <a href="/install" class="how-it-works-cta-link">
+              <a href="/install/" class="how-it-works-cta-link">
                 <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
                 </svg>

--- a/website-shibumi/src/components/InteractiveDemo.tsx
+++ b/website-shibumi/src/components/InteractiveDemo.tsx
@@ -329,7 +329,7 @@ export async function InteractiveDemo() {
 
         <div class="demo-cta fade-in-on-scroll">
           <p class="demo-cta-text">Use these examples after connecting MCPVault to your client.</p>
-          <a href="/install" class="demo-cta-link">
+          <a href="/install/" class="demo-cta-link">
             <DownloadIcon className="icon" />
             Installation
           </a>

--- a/website-shibumi/src/components/Nav.tsx
+++ b/website-shibumi/src/components/Nav.tsx
@@ -28,11 +28,11 @@ export interface NavLink {
 }
 
 export const NAV_LINKS: NavLink[] = [
-  { href: "/install", label: "Install" },
-  { href: "/features", label: "Features" },
-  { href: "/demo", label: "Demo" },
-  { href: "/how-it-works", label: "How It Works", shortLabel: "How" },
-  { href: "/skill", label: "Skill" },
+  { href: "/install/", label: "Install" },
+  { href: "/features/", label: "Features" },
+  { href: "/demo/", label: "Demo" },
+  { href: "/how-it-works/", label: "How It Works", shortLabel: "How" },
+  { href: "/skill/", label: "Skill" },
 ];
 
 export interface NavProps {
@@ -41,8 +41,9 @@ export interface NavProps {
 }
 
 function isActive(currentPath: string, href: string): boolean {
-  const normalized = currentPath.replace(/\/$/, "") || "/";
-  return normalized === href;
+  const normalizedCurrentPath = currentPath.replace(/\/$/, "") || "/";
+  const normalizedHref = href.replace(/\/$/, "") || "/";
+  return normalizedCurrentPath === normalizedHref;
 }
 
 export function Nav({ currentPath, version }: NavProps) {

--- a/website-shibumi/src/components/SkillsContent.tsx
+++ b/website-shibumi/src/components/SkillsContent.tsx
@@ -595,7 +595,7 @@ export function SkillsContent() {
               <div class="skill-cta-text">
                 <h3 class="skill-cta-title">Install the skill</h3>
                 <p class="skill-cta-description">Add routing instructions for MCPVault, Obsidian CLI, and Git.</p>
-                <a href="/install" class="skill-cta-link">
+                <a href="/install/" class="skill-cta-link">
                   <svg class="icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z" />
                   </svg>

--- a/website-shibumi/src/emails/welcome.html
+++ b/website-shibumi/src/emails/welcome.html
@@ -30,7 +30,7 @@
           </table>
           <table cellpadding="0" cellspacing="0"><tr>
             <td style="background-color:#7c3aed;border-radius:8px;">
-              <a href="https://mcpvault.org" style="display:inline-block;padding:10px 24px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">Visit mcpvault.org</a>
+              <a href="https://mcpvault.org/" style="display:inline-block;padding:10px 24px;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">Visit mcpvault.org</a>
             </td>
             <td style="padding-left:12px;">
               <a href="{{unsubscribeUrl}}" style="display:inline-block;padding:10px 24px;font-size:14px;font-weight:600;color:#525252;text-decoration:none;border:1px solid #333;border-radius:8px;">Unsubscribe</a>

--- a/website-shibumi/src/layouts/Layout.tsx
+++ b/website-shibumi/src/layouts/Layout.tsx
@@ -61,7 +61,7 @@ export interface LayoutProps {
   children?: unknown;
 }
 
-export function Layout({ title = DEFAULT_TITLE, description = DEFAULT_DESCRIPTION, image = DEFAULT_IMAGE, canonical = SITE_URL, page, pageStylesheet, clientScript, version = packageVersion, children }: LayoutProps) {
+export function Layout({ title = DEFAULT_TITLE, description = DEFAULT_DESCRIPTION, image = DEFAULT_IMAGE, canonical = `${SITE_URL}/`, page, pageStylesheet, clientScript, version = packageVersion, children }: LayoutProps) {
   const fullTitle = title.includes("MCPVault") ? title : `${title} | MCPVault`;
   // Built by lib/csp.ts so the CSP header's belt-and-braces hash is computed
   // from the exact same serialization this layout renders.

--- a/website-shibumi/src/lib/csp.ts
+++ b/website-shibumi/src/lib/csp.ts
@@ -58,7 +58,7 @@ export function structuredData(version: string) {
     "@type": "SoftwareApplication",
     name: "MCPVault",
     description: "Local MCP server for reading, searching, and editing notes in an Obsidian vault.",
-    url: "https://mcpvault.org",
+    url: "https://mcpvault.org/",
     downloadUrl: "https://www.npmjs.com/package/@bitbonsai/mcpvault",
     softwareVersion: version,
     operatingSystem: ["macOS", "Windows", "Linux"],

--- a/website-shibumi/src/pages/Benchmarks.tsx
+++ b/website-shibumi/src/pages/Benchmarks.tsx
@@ -64,7 +64,7 @@ export function BenchmarksPage({ currentPath, version }: BenchmarksPageProps) {
     <Layout
       title="MCP v2 benchmarks"
       description="MCPVault compatibility benchmarks for current clients and clients using the MCP 2026-07-28 specification."
-      canonical="https://mcpvault.org/benchmarks"
+      canonical="https://mcpvault.org/benchmarks/"
       page="benchmarks"
       pageStylesheet="/styles/benchmarks.css"
       clientScript="/client/alpine.js"

--- a/website-shibumi/src/pages/Demo.tsx
+++ b/website-shibumi/src/pages/Demo.tsx
@@ -27,7 +27,7 @@ export function DemoPage({ currentPath, version }: DemoPageProps) {
     <Layout
       title="Demo"
       description="Tool request and response examples for reading, writing, searching, and updating notes with MCPVault."
-      canonical="https://mcpvault.org/demo"
+      canonical="https://mcpvault.org/demo/"
       page="demo"
       pageStylesheet="/styles/demo.css"
       clientScript="/client/alpine.js"

--- a/website-shibumi/src/pages/Features.tsx
+++ b/website-shibumi/src/pages/Features.tsx
@@ -25,7 +25,7 @@ export function FeaturesPage({ currentPath, version }: FeaturesPageProps) {
     <Layout
       title="Features"
       description="Review MCPVault search, frontmatter, file tools, path restrictions, supported clients, and access methods."
-      canonical="https://mcpvault.org/features"
+      canonical="https://mcpvault.org/features/"
       page="features"
       pageStylesheet="/styles/features.css"
       clientScript="/client/alpine.js"

--- a/website-shibumi/src/pages/HowItWorks.tsx
+++ b/website-shibumi/src/pages/HowItWorks.tsx
@@ -23,7 +23,7 @@ export function HowItWorksPage({ currentPath, version }: HowItWorksPageProps) {
     <Layout
       title="How It Works"
       description="Follow MCPVault search, batch read, and frontmatter update requests from prompt to tool response."
-      canonical="https://mcpvault.org/how-it-works"
+      canonical="https://mcpvault.org/how-it-works/"
       page="how-it-works"
       pageStylesheet="/styles/how-it-works.css"
       clientScript="/client/alpine.js"

--- a/website-shibumi/src/pages/Install.tsx
+++ b/website-shibumi/src/pages/Install.tsx
@@ -23,7 +23,7 @@ export function InstallPage({ currentPath, version }: InstallPageProps) {
     <Layout
       title="Install"
       description="Configuration examples for running MCPVault with Claude Desktop, ChatGPT+, Claude Code, Gemini CLI, OpenCode, and OpenAI Codex."
-      canonical="https://mcpvault.org/install"
+      canonical="https://mcpvault.org/install/"
       page="install"
       pageStylesheet="/styles/install.css"
       clientScript="/client/alpine.js"

--- a/website-shibumi/src/pages/Skill.tsx
+++ b/website-shibumi/src/pages/Skill.tsx
@@ -21,7 +21,7 @@ export function SkillPage({ currentPath, version }: SkillPageProps) {
     <Layout
       title="Skill"
       description="Install an Obsidian skill that routes file operations to MCPVault, app actions to Obsidian CLI, and sync tasks to Git."
-      canonical="https://mcpvault.org/skill"
+      canonical="https://mcpvault.org/skill/"
       page="skill"
       pageStylesheet="/styles/skill.css"
       clientScript="/client/alpine.js"

--- a/website-shibumi/src/routes/unsubscribe.ts
+++ b/website-shibumi/src/routes/unsubscribe.ts
@@ -87,7 +87,7 @@ function unsubscribePageHtml(): string {
           <p style="margin:0 0 24px;font-size:15px;line-height:1.6;color:#a0a0a0;">
             You won't receive any more emails from MCPVault. If this was a mistake, you can re-subscribe on the homepage.
           </p>
-          <a href="https://mcpvault.org" style="display:inline-block;padding:10px 24px;font-size:14px;font-weight:600;color:#ffffff;background-color:#7c3aed;border-radius:8px;text-decoration:none;">Back to mcpvault.org</a>
+          <a href="https://mcpvault.org/" style="display:inline-block;padding:10px 24px;font-size:14px;font-weight:600;color:#ffffff;background-color:#7c3aed;border-radius:8px;text-decoration:none;">Back to mcpvault.org</a>
         </td></tr>
       </table>
     </td></tr>

--- a/website-shibumi/test/routes/app.test.ts
+++ b/website-shibumi/test/routes/app.test.ts
@@ -27,6 +27,14 @@ describe("GET /healthz", () => {
   });
 });
 
+describe("page redirects", () => {
+  test("redirects /benchmarks to its trailing-slash route", async () => {
+    const res = await app.request("/benchmarks?source=reddit", { redirect: "manual" });
+    expect(res.status).toBe(301);
+    expect(res.headers.get("location")).toBe("/benchmarks/?source=reddit");
+  });
+});
+
 describe("security headers", () => {
   test("are present on responses", async () => {
     const res = await app.request("/healthz");

--- a/website-shibumi/test/routes/app.test.ts
+++ b/website-shibumi/test/routes/app.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { createApp } from "../../src/app";
+import { SITE_ROUTES, SITE_URL } from "../../src/routes/seo";
 
 let publicDir: string;
 let app: ReturnType<typeof createApp>;
@@ -28,10 +29,25 @@ describe("GET /healthz", () => {
 });
 
 describe("page redirects", () => {
-  test("redirects /benchmarks to its trailing-slash route", async () => {
-    const res = await app.request("/benchmarks?source=reddit", { redirect: "manual" });
-    expect(res.status).toBe(301);
-    expect(res.headers.get("location")).toBe("/benchmarks/?source=reddit");
+  test("redirects every bare page path to its trailing-slash route", async () => {
+    for (const route of SITE_ROUTES) {
+      if (route === "/") continue;
+      const barePath = route.slice(0, -1);
+      const res = await app.request(`${barePath}?source=test`, { redirect: "manual" });
+      expect(res.status).toBe(301);
+      expect(res.headers.get("location")).toBe(`${route}?source=test`);
+    }
+  });
+
+  test("renders trailing slashes in page links and canonical URLs", async () => {
+    const barePaths = SITE_ROUTES.filter((route) => route !== "/").map((route) => route.slice(0, -1));
+    for (const route of SITE_ROUTES) {
+      const body = await (await app.request(route)).text();
+      expect(body).toContain(`<link rel="canonical" href="${SITE_URL}${route}"/>`);
+      for (const barePath of barePaths) {
+        expect(body).not.toContain(`href="${barePath}"`);
+      }
+    }
   });
 });
 

--- a/website-shibumi/test/routes/demo.test.tsx
+++ b/website-shibumi/test/routes/demo.test.tsx
@@ -40,7 +40,7 @@ describe("GET /demo/ (HTML)", () => {
     const body = await (await app.request("/demo/")).text();
     expect(body).toContain("<title>Demo | MCPVault</title>");
     expect(body).toContain('content="Tool request and response examples for reading, writing, searching, and updating notes with MCPVault."');
-    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/demo"/>');
+    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/demo/"/>');
   });
 
   test("loads the page-specific stylesheet after the shared one", async () => {
@@ -101,7 +101,7 @@ describe("GET /demo/ (HTML)", () => {
 
   test("renders the installation CTA linking to /install", async () => {
     const body = await (await app.request("/demo/")).text();
-    expect(body).toContain('href="/install"');
+    expect(body).toContain('href="/install/"');
     expect(body).toContain("Installation");
   });
 

--- a/website-shibumi/test/routes/features.test.tsx
+++ b/website-shibumi/test/routes/features.test.tsx
@@ -39,7 +39,7 @@ describe("GET /features/ (HTML)", () => {
     const body = await (await app.request("/features/")).text();
     expect(body).toContain("<title>Features | MCPVault</title>");
     expect(body).toContain('content="Review MCPVault search, frontmatter, file tools, path restrictions, supported clients, and access methods."');
-    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/features"/>');
+    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/features/"/>');
   });
 
   test("loads the page-specific stylesheet after the shared one", async () => {
@@ -67,7 +67,7 @@ describe("GET /features/ (HTML)", () => {
     expect(body).toContain("Compare access methods");
     expect(body).toContain("Frontmatter updates");
     expect(body).toContain("Access boundary");
-    expect(body).toContain('href="/install"');
+    expect(body).toContain('href="/install/"');
     expect(body).toContain('href="https://github.com/bitbonsai/mcpvault"');
   });
 

--- a/website-shibumi/test/routes/how-it-works.test.tsx
+++ b/website-shibumi/test/routes/how-it-works.test.tsx
@@ -40,7 +40,7 @@ describe("GET /how-it-works/ (HTML)", () => {
     const body = await (await app.request("/how-it-works/")).text();
     expect(body).toContain("<title>How It Works | MCPVault</title>");
     expect(body).toContain('content="Follow MCPVault search, batch read, and frontmatter update requests from prompt to tool response."');
-    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/how-it-works"/>');
+    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/how-it-works/"/>');
   });
 
   test("loads the page-specific stylesheet after the shared one", async () => {
@@ -73,7 +73,7 @@ describe("GET /how-it-works/ (HTML)", () => {
   test("renders the installation CTA linking to /install", async () => {
     const body = await (await app.request("/how-it-works/")).text();
     expect(body).toContain("What these examples cover");
-    expect(body).toContain('href="/install"');
+    expect(body).toContain('href="/install/"');
     expect(body).toContain("Installation");
   });
 

--- a/website-shibumi/test/routes/install.test.tsx
+++ b/website-shibumi/test/routes/install.test.tsx
@@ -39,7 +39,7 @@ describe("GET /install/ (HTML)", () => {
     const body = await (await app.request("/install/")).text();
     expect(body).toContain("<title>Install | MCPVault</title>");
     expect(body).toContain('content="Configuration examples for running MCPVault with Claude Desktop, ChatGPT+, Claude Code, Gemini CLI, OpenCode, and OpenAI Codex."');
-    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/install"/>');
+    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/install/"/>');
   });
 
   test("loads the page-specific stylesheet after the shared one", async () => {

--- a/website-shibumi/test/routes/shell.test.tsx
+++ b/website-shibumi/test/routes/shell.test.tsx
@@ -27,7 +27,7 @@ function testApp() {
   );
   app.get("/install/", (c) =>
     c.html(
-      <Layout page="install" title="Install" canonical="https://mcpvault.org/install" version="9.9.9">
+      <Layout page="install" title="Install" canonical="https://mcpvault.org/install/" version="9.9.9">
         <Nav currentPath={c.req.path} version="9.9.9" />
         <main id="main-content">install content</main>
         <Footer />
@@ -48,7 +48,7 @@ describe("Layout", () => {
 
   test("sets canonical, Open Graph, and default metadata", async () => {
     const body = await (await testApp().request("/")).text();
-    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org"/>');
+    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/"/>');
     expect(body).toContain('<meta property="og:title" content="MCPVault - MCP Server for Obsidian Vaults"/>');
     expect(body).toContain('<meta name="theme-color" content="#0a0a0a"/>');
   });
@@ -56,7 +56,7 @@ describe("Layout", () => {
   test("per-page title and canonical override the defaults", async () => {
     const body = await (await testApp().request("/install/")).text();
     expect(body).toContain("<title>Install | MCPVault</title>");
-    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/install"/>');
+    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/install/"/>');
   });
 
   test("sets data-page on body for page-scoped CSS", async () => {
@@ -99,8 +99,8 @@ describe("Layout", () => {
 describe("Nav", () => {
   test("marks the current route active and links stay HTML links (works with no JS)", async () => {
     const body = await (await testApp().request("/install/")).text();
-    expect(body).toContain('href="/install" class="nav-link nav-link-active"');
-    expect(body).toContain('href="/features" class="nav-link"');
+    expect(body).toContain('href="/install/" class="nav-link nav-link-active"');
+    expect(body).toContain('href="/features/" class="nav-link"');
   });
 
   test("mobile menu panel is present but hidden without JavaScript", async () => {
@@ -121,7 +121,7 @@ describe("Footer", () => {
     const body = await (await testApp().request("/")).text();
     const year = new Date().getFullYear();
     expect(body).toContain(`© ${year} bitbonsai`);
-    expect(body).toContain('href="/install">Installation</a>');
+    expect(body).toContain('href="/install/">Installation</a>');
   });
 });
 

--- a/website-shibumi/test/routes/skill.test.tsx
+++ b/website-shibumi/test/routes/skill.test.tsx
@@ -39,7 +39,7 @@ describe("GET /skill/ (HTML)", () => {
     const body = await (await app.request("/skill/")).text();
     expect(body).toContain("<title>Skill | MCPVault</title>");
     expect(body).toContain('content="Install an Obsidian skill that routes file operations to MCPVault, app actions to Obsidian CLI, and sync tasks to Git."');
-    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/skill"/>');
+    expect(body).toContain('<link rel="canonical" href="https://mcpvault.org/skill/"/>');
   });
 
   test("loads the page-specific stylesheet after the shared one", async () => {
@@ -108,7 +108,7 @@ describe("GET /skill/ (HTML)", () => {
     const body = await (await app.request("/skill/")).text();
     expect(body).toContain("Quick Start");
     expect(body).toContain("name: obsidian");
-    expect(body).toContain('href="/install"');
+    expect(body).toContain('href="/install/"');
     expect(body).toContain("Installation");
   });
 

--- a/website-shibumi/test/routes/unsubscribe.test.ts
+++ b/website-shibumi/test/routes/unsubscribe.test.ts
@@ -65,7 +65,7 @@ describe("GET /api/unsubscribe", () => {
     expect(calls).toEqual([{ audienceId: "aud_test", email: "person@example.com" }]);
     const body = await res.text();
     expect(body).toContain("<title>Unsubscribed - MCPVault</title>");
-    expect(body).toContain('href="https://mcpvault.org"');
+    expect(body).toContain('href="https://mcpvault.org/"');
   });
 
   test("missing Resend configuration returns 500 with the exact message", async () => {


### PR DESCRIPTION
## Summary

- use trailing slashes in internal page links, canonical metadata, and root links
- derive bare-path redirects from the shared sitemap route list
- preserve query strings when redirecting paths such as `/benchmarks` to `/benchmarks/`
- test every public route for canonical URLs, internal links, and redirect coverage

Both `/page/` and `/page` work. Slash URLs render directly; bare paths return `301` to the slash form.

## Testing

- `cd website-shibumi && bun test` (304 passed)
- `cd website-shibumi && bun run typecheck`
- trailing-slash URL audit
- `git diff --check`
